### PR TITLE
API explorer improvements

### DIFF
--- a/v1.1-events.yml
+++ b/v1.1-events.yml
@@ -1,0 +1,837 @@
+swagger: '2.0'
+info:
+  title: Events API
+  description: Serves the Clever Events API
+  version: 1.1.0
+schemes:
+  - https
+produces:
+  - application/json
+host: api.clever.com
+basePath: /v1.1
+
+responses:
+  BadRequest:
+    description: Bad Request
+    schema:
+      $ref: "#/definitions/BadRequest"
+
+  InternalError:
+    description: Internal Error
+    schema:
+      $ref: "#/definitions/InternalError"
+
+  NotFound:
+    description: Entity Not Found
+    schema:
+      $ref: "#/definitions/NotFound"
+
+security:
+  - oauth: []
+
+paths:
+  /events:
+    get:
+      description: Returns a list of events
+      operationId: getEvents
+      parameters:
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves all events
+
+  /school_admins/{id}/events:
+    get:
+      description: Returns a list of events for a school admin
+      operationId: getEventsForSchoolAdmin
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves events for school_admins.
+
+  /schools/{id}/events:
+    get:
+      description: Returns a list of events for a school
+      operationId: getEventsForSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves events for schools.
+
+  /sections/{id}/events:
+    get:
+      description: Returns a list of events for a section
+      operationId: getEventsForSection
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves events for sections.
+
+  /students/{id}/events:
+    get:
+      description: Returns a list of events for a student
+      operationId: getEventsForStudent
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves events for students.
+
+  /teachers/{id}/events:
+    get:
+      description: Returns a list of events for a teacher
+      operationId: getEventsForTeacher
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves events for teachers.
+
+  /events/{id}:
+    get:
+      description: Returns the specific event
+      operationId: getEvent
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves a single event.
+
+securityDefinitions:
+  oauth:
+    type: oauth2
+    flow: accessCode
+    authorizationUrl: https://clever.com/oauth/authorize
+    tokenUrl: https://clever.com/oauth/tokens
+
+definitions:
+  NotFound:
+    type: object
+    properties:
+      message:
+        type: string
+
+  InternalError:
+    type: object
+    properties:
+      message:
+        type: string
+
+  BadRequest:
+    type: object
+    properties:
+      message:
+        type: string
+
+  EventsResponse:
+    type: object
+    properties:
+      data:
+        type: array
+        items:
+          $ref: "#/definitions/EventResponse"
+
+  EventResponse:
+    type: object
+    properties:
+      data:
+        $ref: "#/definitions/Event"
+
+  Event:
+    type: object
+    discriminator: type
+    properties:
+      type:
+        type: string
+      id:
+        type: string
+    required:
+    - type
+
+  students.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/StudentObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  students.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/StudentObject"
+
+  students.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/StudentObject"
+
+  teachers.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/TeacherObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  teachers.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/TeacherObject"
+
+  teachers.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/TeacherObject"
+
+  sections.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SectionObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  sections.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SectionObject"
+
+  sections.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SectionObject"
+
+  schools.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SchoolObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  schools.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SchoolObject"
+
+  schools.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SchoolObject"
+
+  schooladmins.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SchoolAdminObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  schooladmins.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SchoolAdminObject"
+
+  schooladmins.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SchoolAdminObject"
+
+  studentcontacts.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/StudentContactObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  studentcontacts.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/StudentContactObject"
+
+  studentcontacts.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/StudentContactObject"
+
+  districts.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/DistrictObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  districts.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/DistrictObject"
+
+  districts.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/DistrictObject"
+
+  Student:
+    type: object
+    properties:
+      id:
+        type: string
+      created:
+        type: string
+        format: datetime
+        x-nullable: true
+      district:
+        type: string
+      dob:
+        type: string
+        format: datetime
+        x-nullable: true
+      ell_status:
+        type: string
+        x-nullable: true
+      email:
+        type: string
+        x-nullable: true
+      fcat_reading_level:
+        type: string
+        x-nullable: true
+      frl_status:
+        type: string
+        x-nullable: true
+      gender:
+        type: string
+        x-nullable: true
+      grade:
+        type: string
+        x-nullable: true
+      hispanic_ethnicity:
+        type: string
+        x-nullable: true
+      iep_status:
+        type: string
+        x-nullable: true
+      last_modified:
+        type: string
+        format: datetime
+        x-nullable: true
+      location:
+        $ref: "#/definitions/Location"
+      name:
+        $ref: "#/definitions/Name"
+      race:
+        type: string
+        x-nullable: true
+      rti_behavior:
+        type: string
+        x-nullable: true
+      rti_communication:
+        type: string
+        x-nullable: true
+      rti_ela:
+        type: string
+        x-nullable: true
+      rti_gifted:
+        type: string
+        x-nullable: true
+      rti_health:
+        type: string
+        x-nullable: true
+      rti_math:
+        type: string
+        x-nullable: true
+      rti_social:
+        type: string
+        x-nullable: true
+      school:
+        type: string
+      sis_id:
+        type: string
+        x-nullable: true
+      state_id:
+        type: string
+        x-nullable: true
+      student_number:
+        type: string
+        x-nullable: true
+
+  StudentContact:
+    type: object
+    properties:
+      id:
+        type: string
+      district:
+        type: string
+      email:
+        type: string
+        x-nullable: true
+      name:
+        type: string
+        x-nullable: true
+      phone:
+        type: string
+        x-nullable: true
+      phone_type:
+        type: string
+        x-nullable: true
+      relationship:
+        type: string
+        x-nullable: true
+      student:
+        type: string
+      type:
+        type: string
+        x-nullable: true
+
+  Teacher:
+    type: object
+    properties:
+      id:
+        type: string
+      created:
+        type: string
+        format: datetime
+        x-nullable: true
+      district:
+        type: string
+      email:
+        type: string
+        x-nullable: true
+      last_modified:
+        type: string
+        format: datetime
+        x-nullable: true
+      name:
+        $ref: "#/definitions/Name"
+      school:
+        type: string
+      sis_id:
+        type: string
+        x-nullable: true
+      state_id:
+        type: string
+        x-nullable: true
+      teacher_number:
+        type: string
+        x-nullable: true
+      title:
+        type: string
+        x-nullable: true
+
+  Section:
+    type: object
+    properties:
+      id:
+        type: string
+      course_description:
+        type: string
+        x-nullable: true
+      course_name:
+        type: string
+        x-nullable: true
+      course_number:
+        type: string
+        x-nullable: true
+      created:
+        type: string
+        format: datetime
+        x-nullable: true
+      district:
+        type: string
+      grade:
+        type: string
+        x-nullable: true
+      last_modified:
+        type: string
+        format: datetime
+        x-nullable: true
+      name:
+        type: string
+        x-nullable: true
+      period:
+        type: string
+        x-nullable: true
+      school:
+        type: string
+      section_number:
+        type: string
+        x-nullable: true
+      section_group:
+        type: string
+        x-nullable: true
+      sis_id:
+        type: string
+        x-nullable: true
+      students:
+        type: array
+        items:
+          type: string
+      subject:
+        type: string
+        x-nullable: true
+      teacher:
+        type: string
+        x-nullable: true
+      teachers:
+        type: array
+        items:
+          type: string
+      term:
+        $ref: "#/definitions/Term"
+
+  School:
+    type: object
+    properties:
+      id:
+        type: string
+      created:
+        type: string
+        format: datetime
+        x-nullable: true
+      district:
+        type: string
+      high_grade:
+        type: string
+        x-nullable: true
+      last_modified:
+        type: string
+        format: datetime
+        x-nullable: true
+      location:
+        $ref: "#/definitions/Location"
+      low_grade:
+        type: string
+        x-nullable: true
+      name:
+        type: string
+        x-nullable: true
+      nces_id:
+        type: string
+        x-nullable: true
+      phone:
+        type: string
+        x-nullable: true
+      principal:
+        $ref: "#/definitions/Principal"
+      school_number:
+        type: string
+        x-nullable: true
+      sis_id:
+        type: string
+        x-nullable: true
+      state_id:
+        type: string
+        x-nullable: true
+      mdr_number:
+        type: string
+        x-nullable: true
+
+  SchoolAdmin:
+    type: object
+    properties:
+      id:
+        type: string
+      district:
+        type: string
+      email:
+        type: string
+        x-nullable: true
+      name:
+        $ref: "#/definitions/Name"
+      schools:
+        type: array
+        items:
+          type: string
+      staff_id:
+        type: string
+        x-nullable: true
+      title:
+        type: string
+        x-nullable: true
+
+  District:
+    type: object
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+      mdr_number:
+        type: string
+        x-nullable: true
+
+  Name:
+    type: object
+    properties:
+      first:
+        type: string
+        x-nullable: true
+      middle:
+        type: string
+        x-nullable: true
+      last:
+        type: string
+        x-nullable: true
+
+  Location:
+    type: object
+    properties:
+      address:
+        type: string
+        x-nullable: true
+      city:
+        type: string
+        x-nullable: true
+      state:
+        type: string
+        x-nullable: true
+      zip:
+        type: string
+        x-nullable: true
+      lat:
+        type: string
+        x-nullable: true
+      lon:
+        type: string
+        x-nullable: true
+
+  Term:
+    type: object
+    properties:
+      name:
+        type: string
+        x-nullable: true
+      start_date:
+        type: string
+        format: datetime
+        x-nullable: true
+      end_date:
+        type: string
+        format: datetime
+        x-nullable: true
+
+  Principal:
+    type: object
+    properties:
+      name:
+        type: string
+        x-nullable: true
+      email:
+        type: string
+        x-nullable: true
+
+  StudentObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/Student"
+
+  TeacherObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/Teacher"
+
+  SchoolAdminObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/SchoolAdmin"
+
+  SectionObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/Section"
+
+  StudentContactObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/StudentContact"
+
+  SchoolObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/School"
+
+  DistrictObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/District"

--- a/v1.1-events.yml
+++ b/v1.1-events.yml
@@ -51,7 +51,6 @@ paths:
             $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves all events
 
   /school_admins/{id}/events:
     get:
@@ -78,7 +77,6 @@ paths:
             $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves events for school_admins.
 
   /schools/{id}/events:
     get:
@@ -105,7 +103,6 @@ paths:
             $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves events for schools.
 
   /sections/{id}/events:
     get:
@@ -132,7 +129,6 @@ paths:
             $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves events for sections.
 
   /students/{id}/events:
     get:
@@ -159,7 +155,6 @@ paths:
             $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves events for students.
 
   /teachers/{id}/events:
     get:
@@ -186,7 +181,6 @@ paths:
             $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves events for teachers.
 
   /events/{id}:
     get:
@@ -204,7 +198,6 @@ paths:
             $ref: '#/definitions/EventResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a single event.
 
 securityDefinitions:
   oauth:

--- a/v1.1-events.yml
+++ b/v1.1-events.yml
@@ -32,6 +32,7 @@ security:
 paths:
   /events:
     get:
+      tags: ["Events"]
       description: Returns a list of events
       operationId: getEvents
       parameters:
@@ -52,112 +53,27 @@ paths:
         '404':
           $ref: '#/responses/NotFound'
 
-  /school_admins/{id}/events:
+  /events/{id}:
     get:
-      description: Returns a list of events for a school admin
-      operationId: getEventsForSchoolAdmin
+      tags: ["Events"]
+      description: Returns the specific event
+      operationId: getEvent
       parameters:
       - in: path
         name: id
         required: true
         type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
       responses:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /schools/{id}/events:
-    get:
-      description: Returns a list of events for a school
-      operationId: getEventsForSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /sections/{id}/events:
-    get:
-      description: Returns a list of events for a section
-      operationId: getEventsForSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /students/{id}/events:
-    get:
-      description: Returns a list of events for a student
-      operationId: getEventsForStudent
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
+            $ref: '#/definitions/EventResponse'
         '404':
           $ref: '#/responses/NotFound'
 
   /teachers/{id}/events:
     get:
+      tags: ["Record-specific Events"]
       description: Returns a list of events for a teacher
       operationId: getEventsForTeacher
       parameters:
@@ -182,20 +98,111 @@ paths:
         '404':
           $ref: '#/responses/NotFound'
 
-  /events/{id}:
+  /students/{id}/events:
     get:
-      description: Returns the specific event
-      operationId: getEvent
+      tags: ["Record-specific Events"]
+      description: Returns a list of events for a student
+      operationId: getEventsForStudent
       parameters:
       - in: path
         name: id
         required: true
         type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
       responses:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/EventResponse'
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /sections/{id}/events:
+    get:
+      tags: ["Record-specific Events"]
+      description: Returns a list of events for a section
+      operationId: getEventsForSection
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /schools/{id}/events:
+    get:
+      tags: ["Record-specific Events"]
+      description: Returns a list of events for a school
+      operationId: getEventsForSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /school_admins/{id}/events:
+    get:
+      tags: ["Record-specific Events"]
+      description: Returns a list of events for a school admin
+      operationId: getEventsForSchoolAdmin
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
 

--- a/v1.1.yml
+++ b/v1.1.yml
@@ -30,120 +30,6 @@ security:
   - oauth: []
 
 paths:
-  /contacts:
-    get:
-      tags: ["Contacts"]
-      description: Returns a list of student contacts
-      operationId: getContacts
-      parameters:
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/StudentContactsResponse'
-
-  /contacts/{id}:
-    get:
-      tags: ["Contacts"]
-      description: Returns a specific student contact
-      operationId: getContact
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/StudentContactResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /contacts/{id}/district:
-    get:
-      tags: ["Contacts"]
-      description: Returns the district for a student contact
-      operationId: getDistrictForStudentContact
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/DistrictResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /contacts/{id}/student:
-    get:
-      tags: ["Contacts"]
-      description: Returns the student for a student contact
-      operationId: getStudentForContact
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/StudentResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /district_admins:
-    get:
-      tags: ["District Admins"]
-      description: Returns a list of district admins
-      operationId: getDistrictAdmins
-      parameters:
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      - in: query
-        name: show_links
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/DistrictAdminsResponse'
-
-  /district_admins/{id}:
-    get:
-      tags: ["District Admins"]
-      description: Returns a specific district admin
-      operationId: getDistrictAdmin
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/DistrictAdminResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
   /districts:
     get:
       tags: ["Districts"]
@@ -342,11 +228,11 @@ paths:
         '404':
           $ref: '#/responses/NotFound'
 
-  /school_admins:
+  /teachers:
     get:
-      tags: ["School Admins"]
-      description: Returns a list of school admins
-      operationId: getSchoolAdmins
+      tags: ["Teachers"]
+      description: Returns a list of teachers
+      operationId: getTeachers
       parameters:
       - in: query
         name: limit
@@ -364,13 +250,13 @@ paths:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/SchoolAdminsResponse'
+            $ref: '#/definitions/TeachersResponse'
 
-  /school_admins/{id}:
+  /teachers/{id}:
     get:
-      tags: ["School Admins"]
-      description: Returns a specific school admin
-      operationId: getSchoolAdmin
+      tags: ["Teachers"]
+      description: Returns a specific teacher
+      operationId: getTeacher
       parameters:
       - in: path
         name: id
@@ -383,315 +269,69 @@ paths:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/SchoolAdminResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /school_admins/{id}/schools:
-    get:
-      tags: ["School Admins"]
-      description: Returns the schools for a school admin
-      operationId: getSchoolsForSchoolAdmin
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SchoolsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /schools:
-    get:
-      tags: ["Schools"]
-      description: Returns a list of schools
-      operationId: getSchools
-      parameters:
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      - in: query
-        name: where
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SchoolsResponse'
-
-  /schools/{id}:
-    get:
-      tags: ["Schools"]
-      description: Returns a specific school
-      operationId: getSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SchoolResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /schools/{id}/district:
-    get:
-      tags: ["Schools"]
-      description: Returns the district for a school
-      operationId: getDistrictForSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/DistrictResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /schools/{id}/sections:
-    get:
-      tags: ["Schools"]
-      description: Returns the sections for a school
-      operationId: getSectionsForSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      - in: query
-        name: where
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SectionsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /schools/{id}/students:
-    get:
-      tags: ["Schools"]
-      description: Returns the students for a school
-      operationId: getStudentsForSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      - in: query
-        name: where
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/StudentsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /schools/{id}/teachers:
-    get:
-      tags: ["Schools"]
-      description: Returns the teachers for a school
-      operationId: getTeachersForSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      - in: query
-        name: where
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/TeachersResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /sections:
-    get:
-      tags: ["Sections"]
-      description: Returns a list of sections
-      operationId: getSections
-      parameters:
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      - in: query
-        name: where
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SectionsResponse'
-
-  /sections/{id}:
-    get:
-      tags: ["Sections"]
-      description: Returns a specific section
-      operationId: getSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SectionResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /sections/{id}/district:
-    get:
-      tags: ["Sections"]
-      description: Returns the district for a section
-      operationId: getDistrictForSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/DistrictResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /sections/{id}/school:
-    get:
-      tags: ["Sections"]
-      description: Returns the school for a section
-      operationId: getSchoolForSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SchoolResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /sections/{id}/students:
-    get:
-      tags: ["Sections"]
-      description: Returns the students for a section
-      operationId: getStudentsForSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/StudentsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /sections/{id}/teacher:
-    get:
-      tags: ["Sections"]
-      description: Returns the primary teacher for a section
-      operationId: getTeacherForSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
             $ref: '#/definitions/TeacherResponse'
         '404':
           $ref: '#/responses/NotFound'
 
-  /sections/{id}/teachers:
+  /teachers/{id}/district:
     get:
-      tags: ["Sections"]
-      description: Returns the teachers for a section
-      operationId: getTeachersForSection
+      tags: ["Teachers"]
+      description: Returns the district for a teacher
+      operationId: getDistrictForTeacher
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/DistrictResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /teachers/{id}/grade_levels:
+    get:
+      tags: ["Teachers"]
+      description: Returns the grade levels for sections a teacher teaches
+      operationId: getGradeLevelsForTeacher
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/GradeLevelsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /teachers/{id}/school:
+    get:
+      tags: ["Teachers"]
+      description: Retrieves school info for a teacher.
+      operationId: getSchoolForTeacher
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SchoolResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /teachers/{id}/sections:
+    get:
+      tags: ["Teachers"]
+      description: Returns the sections for a teacher
+      operationId: getSectionsForTeacher
       parameters:
       - in: path
         name: id
@@ -710,7 +350,34 @@ paths:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/TeachersResponse'
+            $ref: '#/definitions/SectionsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /teachers/{id}/students:
+    get:
+      tags: ["Teachers"]
+      description: Returns the students for a teacher
+      operationId: getStudentsForTeacher
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/StudentsResponse'
         '404':
           $ref: '#/responses/NotFound'
 
@@ -870,11 +537,11 @@ paths:
         '404':
           $ref: '#/responses/NotFound'
 
-  /teachers:
+  /sections:
     get:
-      tags: ["Teachers"]
-      description: Returns a list of teachers
-      operationId: getTeachers
+      tags: ["Sections"]
+      description: Returns a list of sections
+      operationId: getSections
       parameters:
       - in: query
         name: limit
@@ -892,34 +559,31 @@ paths:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/TeachersResponse'
+            $ref: '#/definitions/SectionsResponse'
 
-  /teachers/{id}:
+  /sections/{id}:
     get:
-      tags: ["Teachers"]
-      description: Returns a specific teacher
-      operationId: getTeacher
+      tags: ["Sections"]
+      description: Returns a specific section
+      operationId: getSection
       parameters:
       - in: path
         name: id
         required: true
         type: string
-      - in: query
-        name: include
-        type: string
       responses:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/TeacherResponse'
+            $ref: '#/definitions/SectionResponse'
         '404':
           $ref: '#/responses/NotFound'
 
-  /teachers/{id}/district:
+  /sections/{id}/district:
     get:
-      tags: ["Teachers"]
-      description: Returns the district for a teacher
-      operationId: getDistrictForTeacher
+      tags: ["Sections"]
+      description: Returns the district for a section
+      operationId: getDistrictForSection
       parameters:
       - in: path
         name: id
@@ -933,29 +597,11 @@ paths:
         '404':
           $ref: '#/responses/NotFound'
 
-  /teachers/{id}/grade_levels:
+  /sections/{id}/school:
     get:
-      tags: ["Teachers"]
-      description: Returns the grade levels for sections a teacher teaches
-      operationId: getGradeLevelsForTeacher
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/GradeLevelsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /teachers/{id}/school:
-    get:
-      tags: ["Teachers"]
-      description: Retrieves school info for a teacher.
-      operationId: getSchoolForTeacher
+      tags: ["Sections"]
+      description: Returns the school for a section
+      operationId: getSchoolForSection
       parameters:
       - in: path
         name: id
@@ -969,38 +615,11 @@ paths:
         '404':
           $ref: '#/responses/NotFound'
 
-  /teachers/{id}/sections:
+  /sections/{id}/students:
     get:
-      tags: ["Teachers"]
-      description: Returns the sections for a teacher
-      operationId: getSectionsForTeacher
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SectionsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /teachers/{id}/students:
-    get:
-      tags: ["Teachers"]
-      description: Returns the students for a teacher
-      operationId: getStudentsForTeacher
+      tags: ["Sections"]
+      description: Returns the students for a section
+      operationId: getStudentsForSection
       parameters:
       - in: path
         name: id
@@ -1020,6 +639,387 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/StudentsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /sections/{id}/teacher:
+    get:
+      tags: ["Sections"]
+      description: Returns the primary teacher for a section
+      operationId: getTeacherForSection
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/TeacherResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /sections/{id}/teachers:
+    get:
+      tags: ["Sections"]
+      description: Returns the teachers for a section
+      operationId: getTeachersForSection
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/TeachersResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /schools:
+    get:
+      tags: ["Schools"]
+      description: Returns a list of schools
+      operationId: getSchools
+      parameters:
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      - in: query
+        name: where
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SchoolsResponse'
+
+  /schools/{id}:
+    get:
+      tags: ["Schools"]
+      description: Returns a specific school
+      operationId: getSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SchoolResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /schools/{id}/district:
+    get:
+      tags: ["Schools"]
+      description: Returns the district for a school
+      operationId: getDistrictForSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/DistrictResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /schools/{id}/sections:
+    get:
+      tags: ["Schools"]
+      description: Returns the sections for a school
+      operationId: getSectionsForSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      - in: query
+        name: where
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SectionsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /schools/{id}/students:
+    get:
+      tags: ["Schools"]
+      description: Returns the students for a school
+      operationId: getStudentsForSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      - in: query
+        name: where
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/StudentsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /schools/{id}/teachers:
+    get:
+      tags: ["Schools"]
+      description: Returns the teachers for a school
+      operationId: getTeachersForSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      - in: query
+        name: where
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/TeachersResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /contacts:
+    get:
+      tags: ["Contacts"]
+      description: Returns a list of student contacts
+      operationId: getContacts
+      parameters:
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/StudentContactsResponse'
+
+  /contacts/{id}:
+    get:
+      tags: ["Contacts"]
+      description: Returns a specific student contact
+      operationId: getContact
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/StudentContactResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /contacts/{id}/district:
+    get:
+      tags: ["Contacts"]
+      description: Returns the district for a student contact
+      operationId: getDistrictForStudentContact
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/DistrictResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /contacts/{id}/student:
+    get:
+      tags: ["Contacts"]
+      description: Returns the student for a student contact
+      operationId: getStudentForContact
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/StudentResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /district_admins:
+    get:
+      tags: ["District Admins"]
+      description: Returns a list of district admins
+      operationId: getDistrictAdmins
+      parameters:
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      - in: query
+        name: show_links
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/DistrictAdminsResponse'
+
+  /district_admins/{id}:
+    get:
+      tags: ["District Admins"]
+      description: Returns a specific district admin
+      operationId: getDistrictAdmin
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/DistrictAdminResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /school_admins:
+    get:
+      tags: ["School Admins"]
+      description: Returns a list of school admins
+      operationId: getSchoolAdmins
+      parameters:
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      - in: query
+        name: where
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SchoolAdminsResponse'
+
+  /school_admins/{id}:
+    get:
+      tags: ["School Admins"]
+      description: Returns a specific school admin
+      operationId: getSchoolAdmin
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: include
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SchoolAdminResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /school_admins/{id}/schools:
+    get:
+      tags: ["School Admins"]
+      description: Returns the schools for a school admin
+      operationId: getSchoolsForSchoolAdmin
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SchoolsResponse'
         '404':
           $ref: '#/responses/NotFound'
 

--- a/v1.1.yml
+++ b/v1.1.yml
@@ -32,6 +32,7 @@ security:
 paths:
   /contacts:
     get:
+      tags: ["Contacts"]
       description: Returns a list of student contacts
       operationId: getContacts
       parameters:
@@ -49,10 +50,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/StudentContactsResponse'
-      summary: Gets a list of student contacts you have access to.
 
   /contacts/{id}:
     get:
+      tags: ["Contacts"]
       description: Returns a specific student contact
       operationId: getContact
       parameters:
@@ -67,10 +68,10 @@ paths:
             $ref: '#/definitions/StudentContactResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific studentcontact's information.
 
   /contacts/{id}/district:
     get:
+      tags: ["Contacts"]
       description: Returns the district for a student contact
       operationId: getDistrictForStudentContact
       parameters:
@@ -85,10 +86,10 @@ paths:
             $ref: '#/definitions/DistrictResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves the district for a contact.
 
   /contacts/{id}/student:
     get:
+      tags: ["Contacts"]
       description: Returns the student for a student contact
       operationId: getStudentForContact
       parameters:
@@ -103,10 +104,10 @@ paths:
             $ref: '#/definitions/StudentResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves the student for a contact.
 
   /district_admins:
     get:
+      tags: ["District Admins"]
       description: Returns a list of district admins
       operationId: getDistrictAdmins
       parameters:
@@ -124,10 +125,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/DistrictAdminsResponse'
-      summary: Retrieves all users with admin access to a district.
 
   /district_admins/{id}:
     get:
+      tags: ["District Admins"]
       description: Returns a specific district admin
       operationId: getDistrictAdmin
       parameters:
@@ -142,10 +143,10 @@ paths:
             $ref: '#/definitions/DistrictAdminResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a district admin
 
   /districts:
     get:
+      tags: ["Districts"]
       description: Returns a list of districts
       operationId: getDistricts
       parameters:
@@ -163,10 +164,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/DistrictsResponse'
-      summary: Gets a list of districts you have access to.
 
   /districts/{id}:
     get:
+      tags: ["Districts"]
       description: Returns a specific district
       operationId: getDistrict
       parameters:
@@ -184,10 +185,10 @@ paths:
             $ref: '#/definitions/DistrictResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific district's information.
 
   /districts/{id}/admins:
     get:
+      tags: ["Districts"]
       description: Returns the admins for a district
       operationId: getAdminsForDistrict
       parameters:
@@ -202,10 +203,10 @@ paths:
             $ref: '#/definitions/DistrictAdminsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves all the users with admin access to a district.
 
   /districts/{id}/schools:
     get:
+      tags: ["Districts"]
       description: Returns the schools for a district
       operationId: getSchoolsForDistrict
       parameters:
@@ -232,10 +233,10 @@ paths:
             $ref: '#/definitions/SchoolsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of schools you have access to for a specific district.
 
   /districts/{id}/sections:
     get:
+      tags: ["Districts"]
       description: Returns the sections for a district
       operationId: getSectionsForDistrict
       parameters:
@@ -262,10 +263,10 @@ paths:
             $ref: '#/definitions/SectionsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of sections you have access to for a specific district.
 
   /districts/{id}/status:
     get:
+      tags: ["Districts"]
       description: Returns the status of the district
       operationId: getDistrictStatus
       parameters:
@@ -280,10 +281,10 @@ paths:
             $ref: '#/definitions/DistrictStatusResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves the status of a district accessible via your API key.
 
   /districts/{id}/students:
     get:
+      tags: ["Districts"]
       description: Returns the students for a district
       operationId: getStudentsForDistrict
       parameters:
@@ -310,10 +311,10 @@ paths:
             $ref: '#/definitions/StudentsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of students you have access to for a specific district.
 
   /districts/{id}/teachers:
     get:
+      tags: ["Districts"]
       description: Returns the teachers for a district
       operationId: getTeachersForDistrict
       parameters:
@@ -340,10 +341,10 @@ paths:
             $ref: '#/definitions/TeachersResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of teachers you have access to for a specific district.
 
   /school_admins:
     get:
+      tags: ["School Admins"]
       description: Returns a list of school admins
       operationId: getSchoolAdmins
       parameters:
@@ -364,10 +365,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/SchoolAdminsResponse'
-      summary: Gets a list of school_admins you have access to.
 
   /school_admins/{id}:
     get:
+      tags: ["School Admins"]
       description: Returns a specific school admin
       operationId: getSchoolAdmin
       parameters:
@@ -385,10 +386,10 @@ paths:
             $ref: '#/definitions/SchoolAdminResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific schooladmin's information.
 
   /school_admins/{id}/schools:
     get:
+      tags: ["School Admins"]
       description: Returns the schools for a school admin
       operationId: getSchoolsForSchoolAdmin
       parameters:
@@ -412,10 +413,10 @@ paths:
             $ref: '#/definitions/SchoolsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves all schools for a school admin.
 
   /schools:
     get:
+      tags: ["Schools"]
       description: Returns a list of schools
       operationId: getSchools
       parameters:
@@ -436,10 +437,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/SchoolsResponse'
-      summary: Gets a list of schools you have access to.
 
   /schools/{id}:
     get:
+      tags: ["Schools"]
       description: Returns a specific school
       operationId: getSchool
       parameters:
@@ -454,10 +455,10 @@ paths:
             $ref: '#/definitions/SchoolResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific school's information.
 
   /schools/{id}/district:
     get:
+      tags: ["Schools"]
       description: Returns the district for a school
       operationId: getDistrictForSchool
       parameters:
@@ -472,10 +473,10 @@ paths:
             $ref: '#/definitions/DistrictResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves district information for a school.
 
   /schools/{id}/sections:
     get:
+      tags: ["Schools"]
       description: Returns the sections for a school
       operationId: getSectionsForSchool
       parameters:
@@ -502,10 +503,10 @@ paths:
             $ref: '#/definitions/SectionsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all sections for a specific school.
 
   /schools/{id}/students:
     get:
+      tags: ["Schools"]
       description: Returns the students for a school
       operationId: getStudentsForSchool
       parameters:
@@ -532,10 +533,10 @@ paths:
             $ref: '#/definitions/StudentsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all students for a specific school.
 
   /schools/{id}/teachers:
     get:
+      tags: ["Schools"]
       description: Returns the teachers for a school
       operationId: getTeachersForSchool
       parameters:
@@ -562,10 +563,10 @@ paths:
             $ref: '#/definitions/TeachersResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all teachers for a specific school.
 
   /sections:
     get:
+      tags: ["Sections"]
       description: Returns a list of sections
       operationId: getSections
       parameters:
@@ -586,10 +587,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/SectionsResponse'
-      summary: Gets a list of sections you have access to.
 
   /sections/{id}:
     get:
+      tags: ["Sections"]
       description: Returns a specific section
       operationId: getSection
       parameters:
@@ -604,10 +605,10 @@ paths:
             $ref: '#/definitions/SectionResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific section's information.
 
   /sections/{id}/district:
     get:
+      tags: ["Sections"]
       description: Returns the district for a section
       operationId: getDistrictForSection
       parameters:
@@ -622,10 +623,10 @@ paths:
             $ref: '#/definitions/DistrictResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves district information for a section.
 
   /sections/{id}/school:
     get:
+      tags: ["Sections"]
       description: Returns the school for a section
       operationId: getSchoolForSection
       parameters:
@@ -640,10 +641,10 @@ paths:
             $ref: '#/definitions/SchoolResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves information about the school for a section.
 
   /sections/{id}/students:
     get:
+      tags: ["Sections"]
       description: Returns the students for a section
       operationId: getStudentsForSection
       parameters:
@@ -667,10 +668,10 @@ paths:
             $ref: '#/definitions/StudentsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all the section's students.
 
   /sections/{id}/teacher:
     get:
+      tags: ["Sections"]
       description: Returns the primary teacher for a section
       operationId: getTeacherForSection
       parameters:
@@ -685,10 +686,10 @@ paths:
             $ref: '#/definitions/TeacherResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves information about the primary teacher of a section.
 
   /sections/{id}/teachers:
     get:
+      tags: ["Sections"]
       description: Returns the teachers for a section
       operationId: getTeachersForSection
       parameters:
@@ -712,10 +713,10 @@ paths:
             $ref: '#/definitions/TeachersResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all the section's teachers.
 
   /students:
     get:
+      tags: ["Students"]
       description: Returns a list of students
       operationId: getStudents
       parameters:
@@ -736,10 +737,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/StudentsResponse'
-      summary: Gets a list of students you have access to.
 
   /students/{id}:
     get:
+      tags: ["Students"]
       description: Returns a specific student
       operationId: getStudent
       parameters:
@@ -757,10 +758,10 @@ paths:
             $ref: '#/definitions/StudentResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific student's information.
 
   /students/{id}/contacts:
     get:
+      tags: ["Students"]
       description: Returns the contacts for a student
       operationId: getContactsForStudent
       parameters:
@@ -778,10 +779,10 @@ paths:
             $ref: '#/definitions/StudentContactsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves all contacts for a student.
 
   /students/{id}/district:
     get:
+      tags: ["Students"]
       description: Returns the district for a student
       operationId: getDistrictForStudent
       parameters:
@@ -796,10 +797,10 @@ paths:
             $ref: '#/definitions/DistrictResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves district information for a student.
 
   /students/{id}/school:
     get:
+      tags: ["Students"]
       description: Returns the primary school for a student
       operationId: getSchoolForStudent
       parameters:
@@ -814,10 +815,10 @@ paths:
             $ref: '#/definitions/SchoolResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves information about the school for a student
 
   /students/{id}/sections:
     get:
+      tags: ["Students"]
       description: Returns the sections for a student
       operationId: getSectionsForStudent
       parameters:
@@ -841,10 +842,10 @@ paths:
             $ref: '#/definitions/SectionsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all sections for a student.
 
   /students/{id}/teachers:
     get:
+      tags: ["Students"]
       description: Returns the teachers for a student
       operationId: getTeachersForStudent
       parameters:
@@ -868,10 +869,10 @@ paths:
             $ref: '#/definitions/TeachersResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves all teachers for a student.
 
   /teachers:
     get:
+      tags: ["Teachers"]
       description: Returns a list of teachers
       operationId: getTeachers
       parameters:
@@ -892,10 +893,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/TeachersResponse'
-      summary: Gets a list of teachers you have access to.
 
   /teachers/{id}:
     get:
+      tags: ["Teachers"]
       description: Returns a specific teacher
       operationId: getTeacher
       parameters:
@@ -913,10 +914,10 @@ paths:
             $ref: '#/definitions/TeacherResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific teacher's information.
 
   /teachers/{id}/district:
     get:
+      tags: ["Teachers"]
       description: Returns the district for a teacher
       operationId: getDistrictForTeacher
       parameters:
@@ -931,10 +932,10 @@ paths:
             $ref: '#/definitions/DistrictResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves district information for a teacher.
 
   /teachers/{id}/grade_levels:
     get:
+      tags: ["Teachers"]
       description: Returns the grade levels for sections a teacher teaches
       operationId: getGradeLevelsForTeacher
       parameters:
@@ -949,10 +950,10 @@ paths:
             $ref: '#/definitions/GradeLevelsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all grade levels taught by a specific teacher.
 
   /teachers/{id}/school:
     get:
+      tags: ["Teachers"]
       description: Retrieves school info for a teacher.
       operationId: getSchoolForTeacher
       parameters:
@@ -967,10 +968,10 @@ paths:
             $ref: '#/definitions/SchoolResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves information about the school for a teacher
 
   /teachers/{id}/sections:
     get:
+      tags: ["Teachers"]
       description: Returns the sections for a teacher
       operationId: getSectionsForTeacher
       parameters:
@@ -994,10 +995,10 @@ paths:
             $ref: '#/definitions/SectionsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all sections for a teacher.
 
   /teachers/{id}/students:
     get:
+      tags: ["Teachers"]
       description: Returns the students for a teacher
       operationId: getStudentsForTeacher
       parameters:
@@ -1021,7 +1022,6 @@ paths:
             $ref: '#/definitions/StudentsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves all students that a teacher has in their sections.
 
 securityDefinitions:
   oauth:

--- a/v1.1.yml
+++ b/v1.1.yml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
-  title: clever-api
-  description: Serves the Clever API
+  title: Data API
+  description: Serves the Clever Data API
   version: 1.1.0
 schemes:
   - https
@@ -116,8 +116,8 @@ paths:
       - in: query
         name: ending_before
         type: string
-      - in: query    
-        name: show_links   
+      - in: query
+        name: show_links
         type: string
       responses:
         '200':
@@ -174,8 +174,8 @@ paths:
         name: id
         required: true
         type: string
-      - in: query    
-        name: include    
+      - in: query
+        name: include
         type: string
       responses:
         '200':
@@ -375,8 +375,8 @@ paths:
         name: id
         required: true
         type: string
-      - in: query    
-        name: include    
+      - in: query
+        name: include
         type: string
       responses:
         '200':
@@ -1023,182 +1023,6 @@ paths:
           $ref: '#/responses/NotFound'
       summary: Retrieves all students that a teacher has in their sections.
 
-  /events:
-    get:
-      description: Returns a list of events
-      operationId: getEvents
-      parameters:
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves all events
-
-  /school_admins/{id}/events:
-    get:
-      description: Returns a list of events for a school admin
-      operationId: getEventsForSchoolAdmin
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves events for school_admins.
-
-  /schools/{id}/events:
-    get:
-      description: Returns a list of events for a school
-      operationId: getEventsForSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves events for schools.
-
-  /sections/{id}/events:
-    get:
-      description: Returns a list of events for a section
-      operationId: getEventsForSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves events for sections.
-
-  /students/{id}/events:
-    get:
-      description: Returns a list of events for a student
-      operationId: getEventsForStudent
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves events for students.
-
-  /teachers/{id}/events:
-    get:
-      description: Returns a list of events for a teacher
-      operationId: getEventsForTeacher
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves events for teachers.
-
-  /events/{id}:
-    get:
-      description: Returns the specific event
-      operationId: getEvent
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves a single event.
-
 securityDefinitions:
   oauth:
     type: oauth2
@@ -1224,7 +1048,7 @@ definitions:
     properties:
       message:
         type: string
-  
+
   StudentsResponse:
     type: object
     properties:
@@ -1327,7 +1151,7 @@ definitions:
     type: object
     properties:
       data:
-        $ref: "#/definitions/DistrictStatus" 
+        $ref: "#/definitions/DistrictStatus"
 
   GradeLevelsResponse:
     type: object
@@ -1728,259 +1552,3 @@ definitions:
       email:
         type: string
         x-nullable: true
-
-  StudentObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/Student"
-
-  TeacherObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/Teacher"
-
-  SchoolAdminObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/SchoolAdmin"
-
-  SectionObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/Section"
-
-  StudentContactObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/StudentContact"
-
-  SchoolObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/School" 
-
-  DistrictObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/District"
-
-  EventsResponse:
-    type: object
-    properties:
-      data:
-        type: array
-        items:
-          $ref: "#/definitions/EventResponse"
-
-  EventResponse:
-    type: object
-    properties:
-      data:
-        $ref: "#/definitions/Event"
-
-  Event:
-    type: object
-    discriminator: type
-    properties:
-      type:
-        type: string
-      id:
-        type: string
-    required:
-    - type
-
-  students.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/StudentObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  students.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/StudentObject"
-
-  students.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/StudentObject"
-
-  teachers.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/TeacherObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  teachers.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/TeacherObject" 
-
-  teachers.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/TeacherObject"
-
-  sections.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SectionObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  sections.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SectionObject" 
-
-  sections.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SectionObject"
-
-  schools.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SchoolObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  schools.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SchoolObject" 
-
-  schools.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SchoolObject"
-
-  schooladmins.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SchoolAdminObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  schooladmins.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SchoolAdminObject" 
-
-  schooladmins.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SchoolAdminObject"
-
-  studentcontacts.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/StudentContactObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  studentcontacts.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/StudentContactObject" 
-
-  studentcontacts.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/StudentContactObject"
-
-  districts.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/DistrictObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  districts.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/DistrictObject" 
-
-  districts.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/DistrictObject"

--- a/v1.2-events.yml
+++ b/v1.2-events.yml
@@ -32,6 +32,7 @@ security:
 paths:
   /events:
     get:
+      tags: ["Events"]
       description: Returns a list of events
       operationId: getEvents
       parameters:
@@ -52,112 +53,27 @@ paths:
         '404':
           $ref: '#/responses/NotFound'
 
-  /school_admins/{id}/events:
+  /events/{id}:
     get:
-      description: Returns a list of events for a school admin
-      operationId: getEventsForSchoolAdmin
+      tags: ["Events"]
+      description: Returns the specific event
+      operationId: getEvent
       parameters:
       - in: path
         name: id
         required: true
         type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
       responses:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /schools/{id}/events:
-    get:
-      description: Returns a list of events for a school
-      operationId: getEventsForSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /sections/{id}/events:
-    get:
-      description: Returns a list of events for a section
-      operationId: getEventsForSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /students/{id}/events:
-    get:
-      description: Returns a list of events for a student
-      operationId: getEventsForStudent
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
+            $ref: '#/definitions/EventResponse'
         '404':
           $ref: '#/responses/NotFound'
 
   /teachers/{id}/events:
     get:
+      tags: ["Record-specific Events"]
       description: Returns a list of events for a teacher
       operationId: getEventsForTeacher
       parameters:
@@ -182,23 +98,114 @@ paths:
         '404':
           $ref: '#/responses/NotFound'
 
-  /events/{id}:
+  /students/{id}/events:
     get:
-      description: Returns the specific event
-      operationId: getEvent
+      tags: ["Record-specific Events"]
+      description: Returns a list of events for a student
+      operationId: getEventsForStudent
       parameters:
       - in: path
         name: id
         required: true
         type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
       responses:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/EventResponse'
+            $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      
+
+  /sections/{id}/events:
+    get:
+      tags: ["Record-specific Events"]
+      description: Returns a list of events for a section
+      operationId: getEventsForSection
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /schools/{id}/events:
+    get:
+      tags: ["Record-specific Events"]
+      description: Returns a list of events for a school
+      operationId: getEventsForSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /school_admins/{id}/events:
+    get:
+      tags: ["Record-specific Events"]
+      description: Returns a list of events for a school admin
+      operationId: getEventsForSchoolAdmin
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
 securityDefinitions:
   oauth:
     type: oauth2

--- a/v1.2-events.yml
+++ b/v1.2-events.yml
@@ -1,0 +1,845 @@
+swagger: '2.0'
+info:
+  title: Events API
+  description: Serves the Clever Events API
+  version: 1.2.0
+schemes:
+  - https
+produces:
+  - application/json
+host: api.clever.com
+basePath: /v1.2
+
+responses:
+  BadRequest:
+    description: Bad Request
+    schema:
+      $ref: "#/definitions/BadRequest"
+
+  InternalError:
+    description: Internal Error
+    schema:
+      $ref: "#/definitions/InternalError"
+
+  NotFound:
+    description: Entity Not Found
+    schema:
+      $ref: "#/definitions/NotFound"
+
+security:
+  - oauth: []
+
+paths:
+  /events:
+    get:
+      description: Returns a list of events
+      operationId: getEvents
+      parameters:
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves all events
+
+  /school_admins/{id}/events:
+    get:
+      description: Returns a list of events for a school admin
+      operationId: getEventsForSchoolAdmin
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves events for school_admins.
+
+  /schools/{id}/events:
+    get:
+      description: Returns a list of events for a school
+      operationId: getEventsForSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves events for schools.
+
+  /sections/{id}/events:
+    get:
+      description: Returns a list of events for a section
+      operationId: getEventsForSection
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves events for sections.
+
+  /students/{id}/events:
+    get:
+      description: Returns a list of events for a student
+      operationId: getEventsForStudent
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves events for students.
+
+  /teachers/{id}/events:
+    get:
+      description: Returns a list of events for a teacher
+      operationId: getEventsForTeacher
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves events for teachers.
+
+  /events/{id}:
+    get:
+      description: Returns the specific event
+      operationId: getEvent
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/EventResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+      summary: Retrieves a single event.
+
+securityDefinitions:
+  oauth:
+    type: oauth2
+    flow: accessCode
+    authorizationUrl: https://clever.com/oauth/authorize
+    tokenUrl: https://clever.com/oauth/tokens
+
+definitions:
+  NotFound:
+    type: object
+    properties:
+      message:
+        type: string
+
+  InternalError:
+    type: object
+    properties:
+      message:
+        type: string
+
+  BadRequest:
+    type: object
+    properties:
+      message:
+        type: string
+
+  EventsResponse:
+    type: object
+    properties:
+      data:
+        type: array
+        items:
+          $ref: "#/definitions/EventResponse"
+
+  EventResponse:
+    type: object
+    properties:
+      data:
+        $ref: "#/definitions/Event"
+
+  Event:
+    type: object
+    discriminator: type
+    properties:
+      type:
+        type: string
+      id:
+        type: string
+    required:
+    - type
+
+  students.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/StudentObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  students.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/StudentObject"
+
+  students.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/StudentObject"
+
+  teachers.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/TeacherObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  teachers.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/TeacherObject"
+
+  teachers.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/TeacherObject"
+
+  sections.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SectionObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  sections.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SectionObject"
+
+  sections.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SectionObject"
+
+  schools.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SchoolObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  schools.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SchoolObject"
+
+  schools.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SchoolObject"
+
+  schooladmins.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SchoolAdminObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  schooladmins.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SchoolAdminObject"
+
+  schooladmins.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/SchoolAdminObject"
+
+  studentcontacts.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/StudentContactObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  studentcontacts.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/StudentContactObject"
+
+  studentcontacts.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/StudentContactObject"
+
+  districts.updated:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/DistrictObject"
+          previous_attributes:
+            additionalProperties:
+              type: object
+
+  districts.created:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/DistrictObject"
+
+  districts.deleted:
+    allOf:
+      - $ref: "#/definitions/Event"
+      - type: object
+        properties:
+          data:
+            $ref: "#/definitions/DistrictObject"
+
+  Student:
+    type: object
+    properties:
+      id:
+        type: string
+      created:
+        type: string
+        format: datetime
+        x-nullable: true
+      district:
+        type: string
+      dob:
+        type: string
+        format: datetime
+        x-nullable: true
+      ell_status:
+        type: string
+        x-nullable: true
+      email:
+        type: string
+        x-nullable: true
+      fcat_reading_level:
+        type: string
+        x-nullable: true
+      frl_status:
+        type: string
+        x-nullable: true
+      gender:
+        type: string
+        x-nullable: true
+      grade:
+        type: string
+        x-nullable: true
+      hispanic_ethnicity:
+        type: string
+        x-nullable: true
+      iep_status:
+        type: string
+        x-nullable: true
+      last_modified:
+        type: string
+        format: datetime
+        x-nullable: true
+      location:
+        $ref: "#/definitions/Location"
+      name:
+        $ref: "#/definitions/Name"
+      race:
+        type: string
+        x-nullable: true
+      rti_behavior:
+        type: string
+        x-nullable: true
+      rti_communication:
+        type: string
+        x-nullable: true
+      rti_ela:
+        type: string
+        x-nullable: true
+      rti_gifted:
+        type: string
+        x-nullable: true
+      rti_health:
+        type: string
+        x-nullable: true
+      rti_math:
+        type: string
+        x-nullable: true
+      rti_social:
+        type: string
+        x-nullable: true
+      school:
+        type: string
+      schools:
+        type: array
+        items:
+          type: string
+      sis_id:
+        type: string
+        x-nullable: true
+      state_id:
+        type: string
+        x-nullable: true
+      student_number:
+        type: string
+        x-nullable: true
+
+  StudentContact:
+    type: object
+    properties:
+      id:
+        type: string
+      district:
+        type: string
+      email:
+        type: string
+        x-nullable: true
+      name:
+        type: string
+        x-nullable: true
+      phone:
+        type: string
+        x-nullable: true
+      phone_type:
+        type: string
+        x-nullable: true
+      relationship:
+        type: string
+        x-nullable: true
+      student:
+        type: string
+      type:
+        type: string
+        x-nullable: true
+
+  Teacher:
+    type: object
+    properties:
+      id:
+        type: string
+      created:
+        type: string
+        format: datetime
+        x-nullable: true
+      district:
+        type: string
+      email:
+        type: string
+        x-nullable: true
+      last_modified:
+        type: string
+        format: datetime
+        x-nullable: true
+      name:
+        $ref: "#/definitions/Name"
+      school:
+        type: string
+      schools:
+        type: array
+        items:
+          type: string
+      sis_id:
+        type: string
+        x-nullable: true
+      state_id:
+        type: string
+        x-nullable: true
+      teacher_number:
+        type: string
+        x-nullable: true
+      title:
+        type: string
+        x-nullable: true
+
+  Section:
+    type: object
+    properties:
+      id:
+        type: string
+      course_description:
+        type: string
+        x-nullable: true
+      course_name:
+        type: string
+        x-nullable: true
+      course_number:
+        type: string
+        x-nullable: true
+      created:
+        type: string
+        format: datetime
+        x-nullable: true
+      district:
+        type: string
+      grade:
+        type: string
+        x-nullable: true
+      last_modified:
+        type: string
+        format: datetime
+        x-nullable: true
+      name:
+        type: string
+        x-nullable: true
+      period:
+        type: string
+        x-nullable: true
+      school:
+        type: string
+      section_number:
+        type: string
+        x-nullable: true
+      section_group:
+        type: string
+        x-nullable: true
+      sis_id:
+        type: string
+        x-nullable: true
+      students:
+        type: array
+        items:
+          type: string
+      subject:
+        type: string
+        x-nullable: true
+      teacher:
+        type: string
+        x-nullable: true
+      teachers:
+        type: array
+        items:
+          type: string
+      term:
+        $ref: "#/definitions/Term"
+
+  School:
+    type: object
+    properties:
+      id:
+        type: string
+      created:
+        type: string
+        format: datetime
+        x-nullable: true
+      district:
+        type: string
+      high_grade:
+        type: string
+        x-nullable: true
+      last_modified:
+        type: string
+        format: datetime
+        x-nullable: true
+      location:
+        $ref: "#/definitions/Location"
+      low_grade:
+        type: string
+        x-nullable: true
+      name:
+        type: string
+        x-nullable: true
+      nces_id:
+        type: string
+        x-nullable: true
+      phone:
+        type: string
+        x-nullable: true
+      principal:
+        $ref: "#/definitions/Principal"
+      school_number:
+        type: string
+        x-nullable: true
+      sis_id:
+        type: string
+        x-nullable: true
+      state_id:
+        type: string
+        x-nullable: true
+      mdr_number:
+        type: string
+        x-nullable: true
+
+  SchoolAdmin:
+    type: object
+    properties:
+      id:
+        type: string
+      district:
+        type: string
+      email:
+        type: string
+        x-nullable: true
+      name:
+        $ref: "#/definitions/Name"
+      schools:
+        type: array
+        items:
+          type: string
+      staff_id:
+        type: string
+        x-nullable: true
+      title:
+        type: string
+        x-nullable: true
+
+  District:
+    type: object
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+      mdr_number:
+        type: string
+        x-nullable: true
+
+  Name:
+    type: object
+    properties:
+      first:
+        type: string
+        x-nullable: true
+      middle:
+        type: string
+        x-nullable: true
+      last:
+        type: string
+        x-nullable: true
+
+  Location:
+    type: object
+    properties:
+      address:
+        type: string
+        x-nullable: true
+      city:
+        type: string
+        x-nullable: true
+      state:
+        type: string
+        x-nullable: true
+      zip:
+        type: string
+        x-nullable: true
+      lat:
+        type: string
+        x-nullable: true
+      lon:
+        type: string
+        x-nullable: true
+
+  Term:
+    type: object
+    properties:
+      name:
+        type: string
+        x-nullable: true
+      start_date:
+        type: string
+        format: datetime
+        x-nullable: true
+      end_date:
+        type: string
+        format: datetime
+        x-nullable: true
+
+  Principal:
+    type: object
+    properties:
+      name:
+        type: string
+        x-nullable: true
+      email:
+        type: string
+        x-nullable: true
+
+  StudentObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/Student"
+
+  TeacherObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/Teacher"
+
+  SchoolAdminObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/SchoolAdmin"
+
+  SectionObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/Section"
+
+  StudentContactObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/StudentContact"
+
+  SchoolObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/School"
+
+  DistrictObject:
+    type: object
+    properties:
+      object:
+        $ref: "#/definitions/District"

--- a/v1.2-events.yml
+++ b/v1.2-events.yml
@@ -51,7 +51,6 @@ paths:
             $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves all events
 
   /school_admins/{id}/events:
     get:
@@ -78,7 +77,6 @@ paths:
             $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves events for school_admins.
 
   /schools/{id}/events:
     get:
@@ -105,7 +103,6 @@ paths:
             $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves events for schools.
 
   /sections/{id}/events:
     get:
@@ -132,7 +129,6 @@ paths:
             $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves events for sections.
 
   /students/{id}/events:
     get:
@@ -159,7 +155,6 @@ paths:
             $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves events for students.
 
   /teachers/{id}/events:
     get:
@@ -186,7 +181,6 @@ paths:
             $ref: '#/definitions/EventsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves events for teachers.
 
   /events/{id}:
     get:
@@ -204,8 +198,7 @@ paths:
             $ref: '#/definitions/EventResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a single event.
-
+      
 securityDefinitions:
   oauth:
     type: oauth2

--- a/v1.2.yml
+++ b/v1.2.yml
@@ -30,120 +30,6 @@ security:
   - oauth: []
 
 paths:
-  /contacts:
-    get:
-      tags: ["Contacts"]
-      description: Returns a list of student contacts
-      operationId: getContacts
-      parameters:
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/StudentContactsResponse'
-
-  /contacts/{id}:
-    get:
-      tags: ["Contacts"]
-      description: Returns a specific student contact
-      operationId: getContact
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/StudentContactResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /contacts/{id}/district:
-    get:
-      tags: ["Contacts"]
-      description: Returns the district for a student contact
-      operationId: getDistrictForStudentContact
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/DistrictResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /contacts/{id}/student:
-    get:
-      tags: ["Contacts"]
-      description: Returns the student for a student contact
-      operationId: getStudentForContact
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/StudentResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /district_admins:
-    get:
-      tags: ["District Admins"]
-      description: Returns a list of district admins
-      operationId: getDistrictAdmins
-      parameters:
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      - in: query
-        name: show_links
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/DistrictAdminsResponse'
-
-  /district_admins/{id}:
-    get:
-      tags: ["District Admins"]
-      description: Returns a specific district admin
-      operationId: getDistrictAdmin
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/DistrictAdminResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
   /districts:
     get:
       tags: ["Districts"]
@@ -342,11 +228,11 @@ paths:
         '404':
           $ref: '#/responses/NotFound'
 
-  /school_admins:
+  /teachers:
     get:
-      tags: ["School Admins"]
-      description: Returns a list of school admins
-      operationId: getSchoolAdmins
+      tags: ["Teachers"]
+      description: Returns a list of teachers
+      operationId: getTeachers
       parameters:
       - in: query
         name: limit
@@ -364,13 +250,13 @@ paths:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/SchoolAdminsResponse'
+            $ref: '#/definitions/TeachersResponse'
 
-  /school_admins/{id}:
+  /teachers/{id}:
     get:
-      tags: ["School Admins"]
-      description: Returns a specific school admin
-      operationId: getSchoolAdmin
+      tags: ["Teachers"]
+      description: Returns a specific teacher
+      operationId: getTeacher
       parameters:
       - in: path
         name: id
@@ -383,315 +269,69 @@ paths:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/SchoolAdminResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /school_admins/{id}/schools:
-    get:
-      tags: ["School Admins"]
-      description: Returns the schools for a school admin
-      operationId: getSchoolsForSchoolAdmin
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SchoolsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /schools:
-    get:
-      tags: ["Schools"]
-      description: Returns a list of schools
-      operationId: getSchools
-      parameters:
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      - in: query
-        name: where
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SchoolsResponse'
-
-  /schools/{id}:
-    get:
-      tags: ["Schools"]
-      description: Returns a specific school
-      operationId: getSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SchoolResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /schools/{id}/district:
-    get:
-      tags: ["Schools"]
-      description: Returns the district for a school
-      operationId: getDistrictForSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/DistrictResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /schools/{id}/sections:
-    get:
-      tags: ["Schools"]
-      description: Returns the sections for a school
-      operationId: getSectionsForSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      - in: query
-        name: where
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SectionsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /schools/{id}/students:
-    get:
-      tags: ["Schools"]
-      description: Returns the students for a school
-      operationId: getStudentsForSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      - in: query
-        name: where
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/StudentsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /schools/{id}/teachers:
-    get:
-      tags: ["Schools"]
-      description: Returns the teachers for a school
-      operationId: getTeachersForSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      - in: query
-        name: where
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/TeachersResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /sections:
-    get:
-      tags: ["Sections"]
-      description: Returns a list of sections
-      operationId: getSections
-      parameters:
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      - in: query
-        name: where
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SectionsResponse'
-
-  /sections/{id}:
-    get:
-      tags: ["Sections"]
-      description: Returns a specific section
-      operationId: getSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SectionResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /sections/{id}/district:
-    get:
-      tags: ["Sections"]
-      description: Returns the district for a section
-      operationId: getDistrictForSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/DistrictResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /sections/{id}/school:
-    get:
-      tags: ["Sections"]
-      description: Returns the school for a section
-      operationId: getSchoolForSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SchoolResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /sections/{id}/students:
-    get:
-      tags: ["Sections"]
-      description: Returns the students for a section
-      operationId: getStudentsForSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/StudentsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /sections/{id}/teacher:
-    get:
-      tags: ["Sections"]
-      description: Returns the primary teacher for a section
-      operationId: getTeacherForSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
             $ref: '#/definitions/TeacherResponse'
         '404':
           $ref: '#/responses/NotFound'
 
-  /sections/{id}/teachers:
+  /teachers/{id}/district:
     get:
-      tags: ["Sections"]
-      description: Returns the teachers for a section
-      operationId: getTeachersForSection
+      tags: ["Teachers"]
+      description: Returns the district for a teacher
+      operationId: getDistrictForTeacher
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/DistrictResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /teachers/{id}/grade_levels:
+    get:
+      tags: ["Teachers"]
+      description: Returns the grade levels for sections a teacher teaches
+      operationId: getGradeLevelsForTeacher
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/GradeLevelsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /teachers/{id}/school:
+    get:
+      tags: ["Teachers"]
+      description: Retrieves school info for a teacher.
+      operationId: getSchoolForTeacher
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SchoolResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /teachers/{id}/sections:
+    get:
+      tags: ["Teachers"]
+      description: Returns the sections for a teacher
+      operationId: getSectionsForTeacher
       parameters:
       - in: path
         name: id
@@ -710,7 +350,34 @@ paths:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/TeachersResponse'
+            $ref: '#/definitions/SectionsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /teachers/{id}/students:
+    get:
+      tags: ["Teachers"]
+      description: Returns the students for a teacher
+      operationId: getStudentsForTeacher
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/StudentsResponse'
         '404':
           $ref: '#/responses/NotFound'
 
@@ -870,11 +537,11 @@ paths:
         '404':
           $ref: '#/responses/NotFound'
 
-  /teachers:
+  /sections:
     get:
-      tags: ["Teachers"]
-      description: Returns a list of teachers
-      operationId: getTeachers
+      tags: ["Sections"]
+      description: Returns a list of sections
+      operationId: getSections
       parameters:
       - in: query
         name: limit
@@ -892,34 +559,31 @@ paths:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/TeachersResponse'
+            $ref: '#/definitions/SectionsResponse'
 
-  /teachers/{id}:
+  /sections/{id}:
     get:
-      tags: ["Teachers"]
-      description: Returns a specific teacher
-      operationId: getTeacher
+      tags: ["Sections"]
+      description: Returns a specific section
+      operationId: getSection
       parameters:
       - in: path
         name: id
         required: true
         type: string
-      - in: query
-        name: include
-        type: string
       responses:
         '200':
           description: OK Response
           schema:
-            $ref: '#/definitions/TeacherResponse'
+            $ref: '#/definitions/SectionResponse'
         '404':
           $ref: '#/responses/NotFound'
 
-  /teachers/{id}/district:
+  /sections/{id}/district:
     get:
-      tags: ["Teachers"]
-      description: Returns the district for a teacher
-      operationId: getDistrictForTeacher
+      tags: ["Sections"]
+      description: Returns the district for a section
+      operationId: getDistrictForSection
       parameters:
       - in: path
         name: id
@@ -933,29 +597,11 @@ paths:
         '404':
           $ref: '#/responses/NotFound'
 
-  /teachers/{id}/grade_levels:
+  /sections/{id}/school:
     get:
-      tags: ["Teachers"]
-      description: Returns the grade levels for sections a teacher teaches
-      operationId: getGradeLevelsForTeacher
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/GradeLevelsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /teachers/{id}/school:
-    get:
-      tags: ["Teachers"]
-      description: Retrieves school info for a teacher.
-      operationId: getSchoolForTeacher
+      tags: ["Sections"]
+      description: Returns the school for a section
+      operationId: getSchoolForSection
       parameters:
       - in: path
         name: id
@@ -969,38 +615,11 @@ paths:
         '404':
           $ref: '#/responses/NotFound'
 
-  /teachers/{id}/sections:
+  /sections/{id}/students:
     get:
-      tags: ["Teachers"]
-      description: Returns the sections for a teacher
-      operationId: getSectionsForTeacher
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/SectionsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-
-  /teachers/{id}/students:
-    get:
-      tags: ["Teachers"]
-      description: Returns the students for a teacher
-      operationId: getStudentsForTeacher
+      tags: ["Sections"]
+      description: Returns the students for a section
+      operationId: getStudentsForSection
       parameters:
       - in: path
         name: id
@@ -1020,6 +639,387 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/StudentsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /sections/{id}/teacher:
+    get:
+      tags: ["Sections"]
+      description: Returns the primary teacher for a section
+      operationId: getTeacherForSection
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/TeacherResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /sections/{id}/teachers:
+    get:
+      tags: ["Sections"]
+      description: Returns the teachers for a section
+      operationId: getTeachersForSection
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/TeachersResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /schools:
+    get:
+      tags: ["Schools"]
+      description: Returns a list of schools
+      operationId: getSchools
+      parameters:
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      - in: query
+        name: where
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SchoolsResponse'
+
+  /schools/{id}:
+    get:
+      tags: ["Schools"]
+      description: Returns a specific school
+      operationId: getSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SchoolResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /schools/{id}/district:
+    get:
+      tags: ["Schools"]
+      description: Returns the district for a school
+      operationId: getDistrictForSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/DistrictResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /schools/{id}/sections:
+    get:
+      tags: ["Schools"]
+      description: Returns the sections for a school
+      operationId: getSectionsForSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      - in: query
+        name: where
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SectionsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /schools/{id}/students:
+    get:
+      tags: ["Schools"]
+      description: Returns the students for a school
+      operationId: getStudentsForSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      - in: query
+        name: where
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/StudentsResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /schools/{id}/teachers:
+    get:
+      tags: ["Schools"]
+      description: Returns the teachers for a school
+      operationId: getTeachersForSchool
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      - in: query
+        name: where
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/TeachersResponse'
+        '404':
+          $ref: '#/responses/NotFound'          
+
+  /contacts:
+    get:
+      tags: ["Contacts"]
+      description: Returns a list of student contacts
+      operationId: getContacts
+      parameters:
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/StudentContactsResponse'
+
+  /contacts/{id}:
+    get:
+      tags: ["Contacts"]
+      description: Returns a specific student contact
+      operationId: getContact
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/StudentContactResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /contacts/{id}/district:
+    get:
+      tags: ["Contacts"]
+      description: Returns the district for a student contact
+      operationId: getDistrictForStudentContact
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/DistrictResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /contacts/{id}/student:
+    get:
+      tags: ["Contacts"]
+      description: Returns the student for a student contact
+      operationId: getStudentForContact
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/StudentResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /district_admins:
+    get:
+      tags: ["District Admins"]
+      description: Returns a list of district admins
+      operationId: getDistrictAdmins
+      parameters:
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      - in: query
+        name: show_links
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/DistrictAdminsResponse'
+
+  /district_admins/{id}:
+    get:
+      tags: ["District Admins"]
+      description: Returns a specific district admin
+      operationId: getDistrictAdmin
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/DistrictAdminResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /school_admins:
+    get:
+      tags: ["School Admins"]
+      description: Returns a list of school admins
+      operationId: getSchoolAdmins
+      parameters:
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      - in: query
+        name: where
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SchoolAdminsResponse'
+
+  /school_admins/{id}:
+    get:
+      tags: ["School Admins"]
+      description: Returns a specific school admin
+      operationId: getSchoolAdmin
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: include
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SchoolAdminResponse'
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /school_admins/{id}/schools:
+    get:
+      tags: ["School Admins"]
+      description: Returns the schools for a school admin
+      operationId: getSchoolsForSchoolAdmin
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+      - in: query
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SchoolsResponse'
         '404':
           $ref: '#/responses/NotFound'
 

--- a/v1.2.yml
+++ b/v1.2.yml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
-  title: clever-api
-  description: Serves the Clever API
+  title: Data API
+  description: Serves the Clever Data API
   version: 1.2.0
 schemes:
   - https
@@ -116,8 +116,8 @@ paths:
       - in: query
         name: ending_before
         type: string
-      - in: query    
-        name: show_links   
+      - in: query
+        name: show_links
         type: string
       responses:
         '200':
@@ -174,8 +174,8 @@ paths:
         name: id
         required: true
         type: string
-      - in: query    
-        name: include    
+      - in: query
+        name: include
         type: string
       responses:
         '200':
@@ -375,8 +375,8 @@ paths:
         name: id
         required: true
         type: string
-      - in: query    
-        name: include    
+      - in: query
+        name: include
         type: string
       responses:
         '200':
@@ -1023,182 +1023,6 @@ paths:
           $ref: '#/responses/NotFound'
       summary: Retrieves all students that a teacher has in their sections.
 
-  /events:
-    get:
-      description: Returns a list of events
-      operationId: getEvents
-      parameters:
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves all events
-
-  /school_admins/{id}/events:
-    get:
-      description: Returns a list of events for a school admin
-      operationId: getEventsForSchoolAdmin
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves events for school_admins.
-
-  /schools/{id}/events:
-    get:
-      description: Returns a list of events for a school
-      operationId: getEventsForSchool
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves events for schools.
-
-  /sections/{id}/events:
-    get:
-      description: Returns a list of events for a section
-      operationId: getEventsForSection
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves events for sections.
-
-  /students/{id}/events:
-    get:
-      description: Returns a list of events for a student
-      operationId: getEventsForStudent
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves events for students.
-
-  /teachers/{id}/events:
-    get:
-      description: Returns a list of events for a teacher
-      operationId: getEventsForTeacher
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: starting_after
-        type: string
-      - in: query
-        name: ending_before
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventsResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves events for teachers.
-
-  /events/{id}:
-    get:
-      description: Returns the specific event
-      operationId: getEvent
-      parameters:
-      - in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        '200':
-          description: OK Response
-          schema:
-            $ref: '#/definitions/EventResponse'
-        '404':
-          $ref: '#/responses/NotFound'
-      summary: Retrieves a single event.
-
 securityDefinitions:
   oauth:
     type: oauth2
@@ -1224,7 +1048,7 @@ definitions:
     properties:
       message:
         type: string
-  
+
   StudentsResponse:
     type: object
     properties:
@@ -1327,7 +1151,7 @@ definitions:
     type: object
     properties:
       data:
-        $ref: "#/definitions/DistrictStatus" 
+        $ref: "#/definitions/DistrictStatus"
 
   GradeLevelsResponse:
     type: object
@@ -1745,259 +1569,3 @@ definitions:
       email:
         type: string
         x-nullable: true
-
-  StudentObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/Student"
-
-  TeacherObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/Teacher"
-
-  SchoolAdminObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/SchoolAdmin"
-
-  SectionObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/Section"
-
-  StudentContactObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/StudentContact"
-
-  SchoolObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/School" 
-
-  DistrictObject:
-    type: object
-    properties:
-      object:
-        $ref: "#/definitions/District"
-
-  EventsResponse:
-    type: object
-    properties:
-      data:
-        type: array
-        items:
-          $ref: "#/definitions/EventResponse"
-
-  EventResponse:
-    type: object
-    properties:
-      data:
-        $ref: "#/definitions/Event"
-
-  Event:
-    type: object
-    discriminator: type
-    properties:
-      type:
-        type: string
-      id:
-        type: string
-    required:
-    - type
-
-  students.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/StudentObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  students.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/StudentObject"
-
-  students.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/StudentObject"
-
-  teachers.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/TeacherObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  teachers.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/TeacherObject" 
-
-  teachers.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/TeacherObject"
-
-  sections.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SectionObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  sections.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SectionObject" 
-
-  sections.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SectionObject"
-
-  schools.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SchoolObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  schools.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SchoolObject" 
-
-  schools.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SchoolObject"
-
-  schooladmins.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SchoolAdminObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  schooladmins.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SchoolAdminObject" 
-
-  schooladmins.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/SchoolAdminObject"
-
-  studentcontacts.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/StudentContactObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  studentcontacts.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/StudentContactObject" 
-
-  studentcontacts.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/StudentContactObject"
-
-  districts.updated:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/DistrictObject"
-          previous_attributes:
-            additionalProperties:
-              type: object
-
-  districts.created:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/DistrictObject" 
-
-  districts.deleted:
-    allOf:
-      - $ref: "#/definitions/Event"
-      - type: object
-        properties:
-          data:
-            $ref: "#/definitions/DistrictObject"

--- a/v1.2.yml
+++ b/v1.2.yml
@@ -32,6 +32,7 @@ security:
 paths:
   /contacts:
     get:
+      tags: ["Contacts"]
       description: Returns a list of student contacts
       operationId: getContacts
       parameters:
@@ -49,10 +50,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/StudentContactsResponse'
-      summary: Gets a list of student contacts you have access to.
 
   /contacts/{id}:
     get:
+      tags: ["Contacts"]
       description: Returns a specific student contact
       operationId: getContact
       parameters:
@@ -67,10 +68,10 @@ paths:
             $ref: '#/definitions/StudentContactResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific studentcontact's information.
 
   /contacts/{id}/district:
     get:
+      tags: ["Contacts"]
       description: Returns the district for a student contact
       operationId: getDistrictForStudentContact
       parameters:
@@ -85,10 +86,10 @@ paths:
             $ref: '#/definitions/DistrictResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves the district for a contact.
 
   /contacts/{id}/student:
     get:
+      tags: ["Contacts"]
       description: Returns the student for a student contact
       operationId: getStudentForContact
       parameters:
@@ -103,10 +104,10 @@ paths:
             $ref: '#/definitions/StudentResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves the student for a contact.
 
   /district_admins:
     get:
+      tags: ["District Admins"]
       description: Returns a list of district admins
       operationId: getDistrictAdmins
       parameters:
@@ -124,10 +125,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/DistrictAdminsResponse'
-      summary: Retrieves all users with admin access to a district.
 
   /district_admins/{id}:
     get:
+      tags: ["District Admins"]
       description: Returns a specific district admin
       operationId: getDistrictAdmin
       parameters:
@@ -142,10 +143,10 @@ paths:
             $ref: '#/definitions/DistrictAdminResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a district admin
 
   /districts:
     get:
+      tags: ["Districts"]
       description: Returns a list of districts
       operationId: getDistricts
       parameters:
@@ -163,10 +164,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/DistrictsResponse'
-      summary: Gets a list of districts you have access to.
 
   /districts/{id}:
     get:
+      tags: ["Districts"]
       description: Returns a specific district
       operationId: getDistrict
       parameters:
@@ -184,10 +185,10 @@ paths:
             $ref: '#/definitions/DistrictResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific district's information.
 
   /districts/{id}/admins:
     get:
+      tags: ["Districts"]
       description: Returns the admins for a district
       operationId: getAdminsForDistrict
       parameters:
@@ -202,10 +203,10 @@ paths:
             $ref: '#/definitions/DistrictAdminsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves all the users with admin access to a district.
 
   /districts/{id}/schools:
     get:
+      tags: ["Districts"]
       description: Returns the schools for a district
       operationId: getSchoolsForDistrict
       parameters:
@@ -232,10 +233,10 @@ paths:
             $ref: '#/definitions/SchoolsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of schools you have access to for a specific district.
 
   /districts/{id}/sections:
     get:
+      tags: ["Districts"]
       description: Returns the sections for a district
       operationId: getSectionsForDistrict
       parameters:
@@ -262,10 +263,10 @@ paths:
             $ref: '#/definitions/SectionsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of sections you have access to for a specific district.
 
   /districts/{id}/status:
     get:
+      tags: ["Districts"]
       description: Returns the status of the district
       operationId: getDistrictStatus
       parameters:
@@ -280,10 +281,10 @@ paths:
             $ref: '#/definitions/DistrictStatusResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves the status of a district accessible via your API key.
 
   /districts/{id}/students:
     get:
+      tags: ["Districts"]
       description: Returns the students for a district
       operationId: getStudentsForDistrict
       parameters:
@@ -310,10 +311,10 @@ paths:
             $ref: '#/definitions/StudentsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of students you have access to for a specific district.
 
   /districts/{id}/teachers:
     get:
+      tags: ["Districts"]
       description: Returns the teachers for a district
       operationId: getTeachersForDistrict
       parameters:
@@ -340,10 +341,10 @@ paths:
             $ref: '#/definitions/TeachersResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of teachers you have access to for a specific district.
 
   /school_admins:
     get:
+      tags: ["School Admins"]
       description: Returns a list of school admins
       operationId: getSchoolAdmins
       parameters:
@@ -364,10 +365,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/SchoolAdminsResponse'
-      summary: Gets a list of school_admins you have access to.
 
   /school_admins/{id}:
     get:
+      tags: ["School Admins"]
       description: Returns a specific school admin
       operationId: getSchoolAdmin
       parameters:
@@ -385,10 +386,10 @@ paths:
             $ref: '#/definitions/SchoolAdminResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific schooladmin's information.
 
   /school_admins/{id}/schools:
     get:
+      tags: ["School Admins"]
       description: Returns the schools for a school admin
       operationId: getSchoolsForSchoolAdmin
       parameters:
@@ -412,10 +413,10 @@ paths:
             $ref: '#/definitions/SchoolsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves all schools for a school admin.
 
   /schools:
     get:
+      tags: ["Schools"]
       description: Returns a list of schools
       operationId: getSchools
       parameters:
@@ -436,10 +437,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/SchoolsResponse'
-      summary: Gets a list of schools you have access to.
 
   /schools/{id}:
     get:
+      tags: ["Schools"]
       description: Returns a specific school
       operationId: getSchool
       parameters:
@@ -454,10 +455,10 @@ paths:
             $ref: '#/definitions/SchoolResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific school's information.
 
   /schools/{id}/district:
     get:
+      tags: ["Schools"]
       description: Returns the district for a school
       operationId: getDistrictForSchool
       parameters:
@@ -472,10 +473,10 @@ paths:
             $ref: '#/definitions/DistrictResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves district information for a school.
 
   /schools/{id}/sections:
     get:
+      tags: ["Schools"]
       description: Returns the sections for a school
       operationId: getSectionsForSchool
       parameters:
@@ -502,10 +503,10 @@ paths:
             $ref: '#/definitions/SectionsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all sections for a specific school.
 
   /schools/{id}/students:
     get:
+      tags: ["Schools"]
       description: Returns the students for a school
       operationId: getStudentsForSchool
       parameters:
@@ -532,10 +533,10 @@ paths:
             $ref: '#/definitions/StudentsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all students for a specific school.
 
   /schools/{id}/teachers:
     get:
+      tags: ["Schools"]
       description: Returns the teachers for a school
       operationId: getTeachersForSchool
       parameters:
@@ -562,10 +563,10 @@ paths:
             $ref: '#/definitions/TeachersResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all teachers for a specific school.
 
   /sections:
     get:
+      tags: ["Sections"]
       description: Returns a list of sections
       operationId: getSections
       parameters:
@@ -586,10 +587,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/SectionsResponse'
-      summary: Gets a list of sections you have access to.
 
   /sections/{id}:
     get:
+      tags: ["Sections"]
       description: Returns a specific section
       operationId: getSection
       parameters:
@@ -604,10 +605,10 @@ paths:
             $ref: '#/definitions/SectionResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific section's information.
 
   /sections/{id}/district:
     get:
+      tags: ["Sections"]
       description: Returns the district for a section
       operationId: getDistrictForSection
       parameters:
@@ -622,10 +623,10 @@ paths:
             $ref: '#/definitions/DistrictResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves district information for a section.
 
   /sections/{id}/school:
     get:
+      tags: ["Sections"]
       description: Returns the school for a section
       operationId: getSchoolForSection
       parameters:
@@ -640,10 +641,10 @@ paths:
             $ref: '#/definitions/SchoolResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves information about the school for a section.
 
   /sections/{id}/students:
     get:
+      tags: ["Sections"]
       description: Returns the students for a section
       operationId: getStudentsForSection
       parameters:
@@ -667,10 +668,10 @@ paths:
             $ref: '#/definitions/StudentsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all the section's students.
 
   /sections/{id}/teacher:
     get:
+      tags: ["Sections"]
       description: Returns the primary teacher for a section
       operationId: getTeacherForSection
       parameters:
@@ -685,10 +686,10 @@ paths:
             $ref: '#/definitions/TeacherResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves information about the primary teacher of a section.
 
   /sections/{id}/teachers:
     get:
+      tags: ["Sections"]
       description: Returns the teachers for a section
       operationId: getTeachersForSection
       parameters:
@@ -712,10 +713,10 @@ paths:
             $ref: '#/definitions/TeachersResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all the section's teachers.
 
   /students:
     get:
+      tags: ["Students"]
       description: Returns a list of students
       operationId: getStudents
       parameters:
@@ -736,10 +737,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/StudentsResponse'
-      summary: Gets a list of students you have access to.
 
   /students/{id}:
     get:
+      tags: ["Students"]
       description: Returns a specific student
       operationId: getStudent
       parameters:
@@ -757,10 +758,10 @@ paths:
             $ref: '#/definitions/StudentResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific student's information.
 
   /students/{id}/contacts:
     get:
+      tags: ["Students"]
       description: Returns the contacts for a student
       operationId: getContactsForStudent
       parameters:
@@ -778,10 +779,10 @@ paths:
             $ref: '#/definitions/StudentContactsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves all contacts for a student.
 
   /students/{id}/district:
     get:
+      tags: ["Students"]
       description: Returns the district for a student
       operationId: getDistrictForStudent
       parameters:
@@ -796,10 +797,10 @@ paths:
             $ref: '#/definitions/DistrictResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves district information for a student.
 
   /students/{id}/school:
     get:
+      tags: ["Students"]
       description: Returns the primary school for a student
       operationId: getSchoolForStudent
       parameters:
@@ -814,10 +815,10 @@ paths:
             $ref: '#/definitions/SchoolResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves information about the school for a student
 
   /students/{id}/sections:
     get:
+      tags: ["Students"]
       description: Returns the sections for a student
       operationId: getSectionsForStudent
       parameters:
@@ -841,10 +842,10 @@ paths:
             $ref: '#/definitions/SectionsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all sections for a student.
 
   /students/{id}/teachers:
     get:
+      tags: ["Students"]
       description: Returns the teachers for a student
       operationId: getTeachersForStudent
       parameters:
@@ -868,10 +869,10 @@ paths:
             $ref: '#/definitions/TeachersResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves all teachers for a student.
 
   /teachers:
     get:
+      tags: ["Teachers"]
       description: Returns a list of teachers
       operationId: getTeachers
       parameters:
@@ -892,10 +893,10 @@ paths:
           description: OK Response
           schema:
             $ref: '#/definitions/TeachersResponse'
-      summary: Gets a list of teachers you have access to.
 
   /teachers/{id}:
     get:
+      tags: ["Teachers"]
       description: Returns a specific teacher
       operationId: getTeacher
       parameters:
@@ -913,10 +914,10 @@ paths:
             $ref: '#/definitions/TeacherResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Get only a specific teacher's information.
 
   /teachers/{id}/district:
     get:
+      tags: ["Teachers"]
       description: Returns the district for a teacher
       operationId: getDistrictForTeacher
       parameters:
@@ -931,10 +932,10 @@ paths:
             $ref: '#/definitions/DistrictResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves district information for a teacher.
 
   /teachers/{id}/grade_levels:
     get:
+      tags: ["Teachers"]
       description: Returns the grade levels for sections a teacher teaches
       operationId: getGradeLevelsForTeacher
       parameters:
@@ -949,10 +950,10 @@ paths:
             $ref: '#/definitions/GradeLevelsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all grade levels taught by a specific teacher.
 
   /teachers/{id}/school:
     get:
+      tags: ["Teachers"]
       description: Retrieves school info for a teacher.
       operationId: getSchoolForTeacher
       parameters:
@@ -967,10 +968,10 @@ paths:
             $ref: '#/definitions/SchoolResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves information about the school for a teacher
 
   /teachers/{id}/sections:
     get:
+      tags: ["Teachers"]
       description: Returns the sections for a teacher
       operationId: getSectionsForTeacher
       parameters:
@@ -994,10 +995,10 @@ paths:
             $ref: '#/definitions/SectionsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves a list of all sections for a teacher.
 
   /teachers/{id}/students:
     get:
+      tags: ["Teachers"]
       description: Returns the students for a teacher
       operationId: getStudentsForTeacher
       parameters:
@@ -1021,7 +1022,6 @@ paths:
             $ref: '#/definitions/StudentsResponse'
         '404':
           $ref: '#/responses/NotFound'
-      summary: Retrieves all students that a teacher has in their sections.
 
 securityDefinitions:
   oauth:


### PR DESCRIPTION
- Adds tags to each endpoint to group them together in readme.io
- Removes 'summary' from each endpoint so that the path is displayed in readme.io
- Reorders the resources to _almost_ match our old explorer. The new ordering is:

1. Districts
1. Teachers
1. Students
1. Sections
1. Schools
1. Contacts
1. District Admins
1. School Admins
1. Events

Tested by importing both to readme.io and they are able to be parsed correctly
![image](https://cloud.githubusercontent.com/assets/17581886/24433018/d73d8c82-13da-11e7-94be-71f71e109bf4.png)

