### PR TITLE
Add default token

### DIFF
--- a/full.yml
+++ b/full.yml
@@ -1204,6 +1204,7 @@ securityDefinitions:
     flow: accessCode
     authorizationUrl: https://clever.com/oauth/authorize
     tokenUrl: https://clever.com/oauth/tokens
+    x-default: DEMO_TOKEN
 
 definitions:
   NotFound:

--- a/v1.1-events.yml
+++ b/v1.1-events.yml
@@ -1015,6 +1015,7 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
+    x-default: DEMO_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl

--- a/v1.2-client.yml
+++ b/v1.2-client.yml
@@ -1948,6 +1948,7 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
+    x-default: DEMO_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl

--- a/v1.2-events.yml
+++ b/v1.2-events.yml
@@ -1047,6 +1047,7 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
+    x-default: DEMO_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl

--- a/v1.2.yml
+++ b/v1.2.yml
@@ -1659,6 +1659,7 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
+    x-default: DEMO_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl


### PR DESCRIPTION
Adds our default DEMO_TOKEN to the security definition. This is used by Readme.io for their API explorer