### PR TITLE
Add "links" property to all data apis that return multiple items.

### DIFF
--- a/v2.0-client.yml
+++ b/v2.0-client.yml
@@ -74,12 +74,14 @@ definitions:
         $ref: '#/definitions/Contact'
     type: object
   ContactsResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/ContactResponse'
-        type: array
-    type: object
+    allOf:
+      - properties:
+          data:
+            items:
+              $ref: '#/definitions/ContactResponse'
+            type: array
+        type: object
+      - $ref: '#/definitions/PluralResponse'
   Course:
     properties:
       id:
@@ -103,12 +105,14 @@ definitions:
         $ref: '#/definitions/Course'
     type: object
   CoursesResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/CourseResponse'
-        type: array
-    type: object
+    allOf:
+      - properties:
+          data:
+            items:
+              $ref: '#/definitions/CourseResponse'
+            type: array
+        type: object
+      - $ref: '#/definitions/PluralResponse'
   Credentials:
     properties:
       district_username:
@@ -188,12 +192,14 @@ definitions:
         $ref: '#/definitions/DistrictAdmin'
     type: object
   DistrictAdminsResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/DistrictAdminResponse'
-        type: array
-    type: object
+    allOf:
+      - properties:
+          data:
+            items:
+              $ref: '#/definitions/DistrictAdminResponse'
+            type: array
+        type: object
+      - $ref: '#/definitions/PluralResponse'
   DistrictObject:
     properties:
       object:
@@ -205,12 +211,14 @@ definitions:
         $ref: '#/definitions/District'
     type: object
   DistrictsResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/DistrictResponse'
-        type: array
-    type: object
+    allOf:
+      - properties:
+          data:
+            items:
+              $ref: '#/definitions/DistrictResponse'
+            type: array
+        type: object
+      - $ref: '#/definitions/PluralResponse'
   Event:
     discriminator: type
     properties:
@@ -233,15 +241,28 @@ definitions:
         $ref: '#/definitions/Event'
     type: object
   EventsResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/EventResponse'
-        type: array
-    type: object
+    allOf:
+      - properties:
+          data:
+            items:
+              $ref: '#/definitions/EventResponse'
+            type: array
+        type: object
+      - $ref: '#/definitions/PluralResponse'
   InternalError:
     properties:
       message:
+        type: string
+    type: object
+  Link:
+    properties:
+      rel:
+        enum:
+        - next
+        - prev
+        - self
+        type: string
+      uri:
         type: string
     type: object
   Location:
@@ -281,6 +302,13 @@ definitions:
     properties:
       message:
         type: string
+    type: object
+  PluralResponse:
+    properties:
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Principal:
     properties:
@@ -409,12 +437,14 @@ definitions:
         $ref: '#/definitions/SchoolAdmin'
     type: object
   SchoolAdminsResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/SchoolAdminResponse'
-        type: array
-    type: object
+    allOf:
+      - properties:
+          data:
+            items:
+              $ref: '#/definitions/SchoolAdminResponse'
+            type: array
+        type: object
+      - $ref: '#/definitions/PluralResponse'
   SchoolObject:
     properties:
       object:
@@ -426,12 +456,14 @@ definitions:
         $ref: '#/definitions/School'
     type: object
   SchoolsResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/SchoolResponse'
-        type: array
-    type: object
+    allOf:
+      - properties:
+          data:
+            items:
+              $ref: '#/definitions/SchoolResponse'
+            type: array
+        type: object
+      - $ref: '#/definitions/PluralResponse'
   Section:
     properties:
       course:
@@ -531,12 +563,14 @@ definitions:
         $ref: '#/definitions/Section'
     type: object
   SectionsResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/SectionResponse'
-        type: array
-    type: object
+    allOf:
+      - properties:
+          data:
+            items:
+              $ref: '#/definitions/SectionResponse'
+            type: array
+        type: object
+      - $ref: '#/definitions/PluralResponse'
   Student:
     properties:
       created:
@@ -719,12 +753,14 @@ definitions:
         $ref: '#/definitions/Student'
     type: object
   StudentsResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/StudentResponse'
-        type: array
-    type: object
+    allOf:
+      - properties:
+          data:
+            items:
+              $ref: '#/definitions/StudentResponse'
+            type: array
+        type: object
+      - $ref: '#/definitions/PluralResponse'
   Teacher:
     properties:
       created:
@@ -780,12 +816,14 @@ definitions:
         $ref: '#/definitions/Teacher'
     type: object
   TeachersResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/TeacherResponse'
-        type: array
-    type: object
+    allOf:
+      - properties:
+          data:
+            items:
+              $ref: '#/definitions/TeacherResponse'
+            type: array
+        type: object
+      - $ref: '#/definitions/PluralResponse'
   Term:
     properties:
       end_date:
@@ -816,12 +854,14 @@ definitions:
         $ref: '#/definitions/Term'
     type: object
   TermsResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/TermResponse'
-        type: array
-    type: object
+    allOf:
+      - properties:
+          data:
+            items:
+              $ref: '#/definitions/TermResponse'
+            type: array
+        type: object
+      - $ref: '#/definitions/PluralResponse'
   contacts.created:
     allOf:
     - $ref: '#/definitions/Event'


### PR DESCRIPTION
The Data API responses do not include the "links" property used for pagination.  This change updates the swagger definition to include it in all apis that return multiple items.  I was looking for this functionality in the csharp-clever project.  It needs to be added here first and then the various language-specific libraries can be regenerated to include it.

The links property is documented at the url below.
https://dev.clever.com/v2.0/reference#section-using-relative-links-for-pagination