### PR TITLE
Add district reference to Course and Term objects

### DIFF
--- a/full-v2.yml
+++ b/full-v2.yml
@@ -2068,6 +2068,9 @@ definitions:
         format: datetime
         x-nullable: true
         x-validation: true
+      district:
+        type: string
+        x-validation: true
 
   Course:
     type: object
@@ -2081,6 +2084,9 @@ definitions:
       number:
         type: string
         x-nullable: true
+      district:
+        type: string
+        x-validation: true
 
   Credentials:
     type: object

--- a/v2.0-events.yml
+++ b/v2.0-events.yml
@@ -82,6 +82,9 @@ definitions:
     type: object
   Course:
     properties:
+      district:
+        type: string
+        x-validation: true
       id:
         type: string
         x-validation: true
@@ -727,6 +730,9 @@ definitions:
     type: object
   Term:
     properties:
+      district:
+        type: string
+        x-validation: true
       end_date:
         format: datetime
         type: string

--- a/v2.0.yml
+++ b/v2.0.yml
@@ -77,6 +77,9 @@ definitions:
     type: object
   Course:
     properties:
+      district:
+        type: string
+        x-validation: true
       id:
         type: string
         x-validation: true
@@ -654,6 +657,9 @@ definitions:
     type: object
   Term:
     properties:
+      district:
+        type: string
+        x-validation: true
       end_date:
         format: datetime
         type: string

--- a/v2.1-client.yml
+++ b/v2.1-client.yml
@@ -83,6 +83,9 @@ definitions:
     type: object
   Course:
     properties:
+      district:
+        type: string
+        x-validation: true
       id:
         type: string
         x-validation: true
@@ -864,6 +867,9 @@ definitions:
     type: object
   Term:
     properties:
+      district:
+        type: string
+        x-validation: true
       end_date:
         format: datetime
         type: string

--- a/v2.1-events.yml
+++ b/v2.1-events.yml
@@ -83,6 +83,9 @@ definitions:
     type: object
   Course:
     properties:
+      district:
+        type: string
+        x-validation: true
       id:
         type: string
         x-validation: true
@@ -802,6 +805,9 @@ definitions:
     type: object
   Term:
     properties:
+      district:
+        type: string
+        x-validation: true
       end_date:
         format: datetime
         type: string

--- a/v2.1.yml
+++ b/v2.1.yml
@@ -78,6 +78,9 @@ definitions:
     type: object
   Course:
     properties:
+      district:
+        type: string
+        x-validation: true
       id:
         type: string
         x-validation: true
@@ -729,6 +732,9 @@ definitions:
     type: object
   Term:
     properties:
+      district:
+        type: string
+        x-validation: true
       end_date:
         format: datetime
         type: string


### PR DESCRIPTION
We accidentally left out the `district` reference on Course and Term objects