### PR TITLE
Add Pagination Links to v2 API

### DIFF
--- a/full-v2.yml
+++ b/full-v2.yml
@@ -1252,6 +1252,18 @@ definitions:
       message:
         type: string
 
+  Link:
+    properties:
+      rel:
+        enum:
+          - next
+          - prev
+          - self
+        type: string
+      uri:
+        type: string
+    type: object
+
   BadRequest:
     type: object
     properties:
@@ -1265,6 +1277,10 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/StudentResponse"
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
 
   StudentResponse:
     type: object
@@ -1279,6 +1295,10 @@ definitions:
         type: array
         items:
            $ref: "#/definitions/ContactResponse"
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
 
   ContactResponse:
     type: object
@@ -1293,6 +1313,10 @@ definitions:
         type: array
         items:
            $ref: "#/definitions/TeacherResponse"
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
 
   TeacherResponse:
     type: object
@@ -1307,6 +1331,10 @@ definitions:
         type: array
         items:
            $ref: "#/definitions/SectionResponse"
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
 
   SectionResponse:
     type: object
@@ -1321,6 +1349,10 @@ definitions:
         type: array
         items:
            $ref: "#/definitions/SchoolResponse"
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
 
   SchoolResponse:
     type: object
@@ -1335,6 +1367,10 @@ definitions:
         type: array
         items:
            $ref: "#/definitions/SchoolAdminResponse"
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
 
   SchoolAdminResponse:
     type: object
@@ -1349,6 +1385,10 @@ definitions:
         type: array
         items:
            $ref: "#/definitions/TermResponse"
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
 
   TermResponse:
     type: object
@@ -1363,6 +1403,10 @@ definitions:
         type: array
         items:
            $ref: "#/definitions/CourseResponse"
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
 
   CourseResponse:
     type: object
@@ -1377,6 +1421,10 @@ definitions:
         type: array
         items:
            $ref: "#/definitions/DistrictResponse"
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
 
   DistrictResponse:
     type: object
@@ -1391,6 +1439,10 @@ definitions:
         type: array
         items:
            $ref: "#/definitions/DistrictAdminResponse"
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
 
   DistrictAdminResponse:
     type: object
@@ -2171,6 +2223,10 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/EventResponse"
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
 
   EventResponse:
     type: object

--- a/v2.0-events.yml
+++ b/v2.0-events.yml
@@ -79,6 +79,10 @@ definitions:
         items:
           $ref: '#/definitions/ContactResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Course:
     properties:
@@ -110,6 +114,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/CourseResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Credentials:
@@ -196,6 +204,10 @@ definitions:
         items:
           $ref: '#/definitions/DistrictAdminResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   DistrictObject:
     properties:
@@ -212,6 +224,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/DistrictResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Event:
@@ -241,10 +257,25 @@ definitions:
         items:
           $ref: '#/definitions/EventResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   InternalError:
     properties:
       message:
+        type: string
+    type: object
+  Link:
+    properties:
+      rel:
+        enum:
+        - next
+        - prev
+        - self
+        type: string
+      uri:
         type: string
     type: object
   Location:
@@ -426,6 +457,10 @@ definitions:
         items:
           $ref: '#/definitions/SchoolAdminResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   SchoolObject:
     properties:
@@ -442,6 +477,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/SchoolResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Section:
@@ -547,6 +586,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/SectionResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Student:
@@ -675,6 +718,10 @@ definitions:
         items:
           $ref: '#/definitions/StudentResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Teacher:
     properties:
@@ -736,6 +783,10 @@ definitions:
         items:
           $ref: '#/definitions/TeacherResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Term:
     properties:
@@ -774,6 +825,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/TermResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   contacts.created:

--- a/v2.0.yml
+++ b/v2.0.yml
@@ -74,6 +74,10 @@ definitions:
         items:
           $ref: '#/definitions/ContactResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Course:
     properties:
@@ -100,6 +104,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/CourseResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Credentials:
@@ -181,6 +189,10 @@ definitions:
         items:
           $ref: '#/definitions/DistrictAdminResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   DistrictResponse:
     properties:
@@ -193,10 +205,25 @@ definitions:
         items:
           $ref: '#/definitions/DistrictResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   InternalError:
     properties:
       message:
+        type: string
+    type: object
+  Link:
+    properties:
+      rel:
+        enum:
+        - next
+        - prev
+        - self
+        type: string
+      uri:
         type: string
     type: object
   Location:
@@ -373,6 +400,10 @@ definitions:
         items:
           $ref: '#/definitions/SchoolAdminResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   SchoolResponse:
     properties:
@@ -384,6 +415,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/SchoolResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Section:
@@ -484,6 +519,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/SectionResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Student:
@@ -607,6 +646,10 @@ definitions:
         items:
           $ref: '#/definitions/StudentResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Teacher:
     properties:
@@ -663,6 +706,10 @@ definitions:
         items:
           $ref: '#/definitions/TeacherResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Term:
     properties:
@@ -696,6 +743,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/TermResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
 host: api.clever.com

--- a/v2.1-client.yml
+++ b/v2.1-client.yml
@@ -80,6 +80,10 @@ definitions:
         items:
           $ref: '#/definitions/ContactResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Course:
     properties:
@@ -111,6 +115,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/CourseResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Credentials:
@@ -210,6 +218,10 @@ definitions:
         items:
           $ref: '#/definitions/DistrictAdminResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   DistrictObject:
     properties:
@@ -226,6 +238,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/DistrictResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Event:
@@ -255,10 +271,25 @@ definitions:
         items:
           $ref: '#/definitions/EventResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   InternalError:
     properties:
       message:
+        type: string
+    type: object
+  Link:
+    properties:
+      rel:
+        enum:
+        - next
+        - prev
+        - self
+        type: string
+      uri:
         type: string
     type: object
   Location:
@@ -458,6 +489,10 @@ definitions:
         items:
           $ref: '#/definitions/SchoolAdminResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   SchoolEnrollment:
     properties:
@@ -488,6 +523,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/SchoolResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Section:
@@ -603,6 +642,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/SectionResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Student:
@@ -807,6 +850,10 @@ definitions:
         items:
           $ref: '#/definitions/StudentResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Teacher:
     properties:
@@ -870,6 +917,10 @@ definitions:
         items:
           $ref: '#/definitions/TeacherResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Term:
     properties:
@@ -908,6 +959,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/TermResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   contacts.created:

--- a/v2.1-events.yml
+++ b/v2.1-events.yml
@@ -80,6 +80,10 @@ definitions:
         items:
           $ref: '#/definitions/ContactResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Course:
     properties:
@@ -111,6 +115,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/CourseResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Credentials:
@@ -209,6 +217,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/DistrictAdminResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   DistrictObject:
@@ -458,6 +470,10 @@ definitions:
         items:
           $ref: '#/definitions/SchoolAdminResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   SchoolEnrollment:
     properties:
@@ -488,6 +504,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/SchoolResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Section:
@@ -603,6 +623,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/SectionResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Student:
@@ -745,6 +769,10 @@ definitions:
         items:
           $ref: '#/definitions/StudentResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Teacher:
     properties:
@@ -808,6 +836,10 @@ definitions:
         items:
           $ref: '#/definitions/TeacherResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Term:
     properties:
@@ -846,6 +878,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/TermResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   contacts.created:

--- a/v2.1.yml
+++ b/v2.1.yml
@@ -75,6 +75,10 @@ definitions:
         items:
           $ref: '#/definitions/ContactResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Course:
     properties:
@@ -102,6 +106,10 @@ definitions:
         items:
           $ref: '#/definitions/CourseResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Credentials:
     properties:
@@ -116,6 +124,13 @@ definitions:
         x-validation: true
       error:
         type: string
+      goals_enabled:
+        enum:
+        - "Y"
+        - "N"
+        - ""
+        type: string
+        x-validation: true
       id:
         type: string
         x-validation: true
@@ -178,7 +193,7 @@ definitions:
         type: string
         x-validation: true
       name:
-        $ref: '#/definitions/AdminName'
+        $ref: '#/definitions/Name'
         x-nullable: true
       title:
         type: string
@@ -195,6 +210,10 @@ definitions:
         items:
           $ref: '#/definitions/DistrictAdminResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   DistrictResponse:
     properties:
@@ -207,10 +226,25 @@ definitions:
         items:
           $ref: '#/definitions/DistrictResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   InternalError:
     properties:
       message:
+        type: string
+    type: object
+  Link:
+    properties:
+      rel:
+        enum:
+        - next
+        - prev
+        - self
+        type: string
+      uri:
         type: string
     type: object
   Location:
@@ -405,6 +439,10 @@ definitions:
         items:
           $ref: '#/definitions/SchoolAdminResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   SchoolEnrollment:
     properties:
@@ -430,6 +468,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/SchoolResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Section:
@@ -540,6 +582,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/SectionResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
   Student:
@@ -677,6 +723,10 @@ definitions:
         items:
           $ref: '#/definitions/StudentResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Teacher:
     properties:
@@ -735,6 +785,10 @@ definitions:
         items:
           $ref: '#/definitions/TeacherResponse'
         type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
     type: object
   Term:
     properties:
@@ -768,6 +822,10 @@ definitions:
       data:
         items:
           $ref: '#/definitions/TermResponse'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
         type: array
     type: object
 host: api.clever.com


### PR DESCRIPTION
@jonjonray @emilyhou @johnhuangclever 

The Data API responses do not include the "links" property used for pagination. This change updates the swagger definition for V2 to include it in all apis that return multiple items. I was looking for this functionality for use in a golang project. It needs to be added here first and then the various language-specific libraries can be regenerated to include it.

The links property is documented at the url below.
https://dev.clever.com/reference#section-using-relative-links-for-pagination

Signed-off-by: Steve Coffman <steve@khanacademy.org>