### PR TITLE
Remove test token

### DIFF
--- a/full-v1.yml
+++ b/full-v1.yml
@@ -1204,7 +1204,6 @@ securityDefinitions:
     flow: accessCode
     authorizationUrl: https://clever.com/oauth/authorize
     tokenUrl: https://clever.com/oauth/tokens
-    x-default: TEST_TOKEN
 
 definitions:
   NotFound:

--- a/full-v2.yml
+++ b/full-v2.yml
@@ -1237,7 +1237,6 @@ securityDefinitions:
     flow: accessCode
     authorizationUrl: https://clever.com/oauth/authorize
     tokenUrl: https://clever.com/oauth/tokens
-    x-default: TEST_TOKEN
 
 definitions:
   NotFound:

--- a/v1.1-events.yml
+++ b/v1.1-events.yml
@@ -1022,7 +1022,6 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
-    x-default: TEST_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl

--- a/v1.1.yml
+++ b/v1.1.yml
@@ -1634,7 +1634,6 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
-    x-default: TEST_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl

--- a/v1.2-client.yml
+++ b/v1.2-client.yml
@@ -1955,7 +1955,6 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
-    x-default: TEST_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl

--- a/v1.2-events.yml
+++ b/v1.2-events.yml
@@ -1054,7 +1054,6 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
-    x-default: TEST_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl

--- a/v1.2.yml
+++ b/v1.2.yml
@@ -1666,7 +1666,6 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
-    x-default: TEST_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl

--- a/v2.0-events.yml
+++ b/v2.0-events.yml
@@ -1152,7 +1152,6 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
-    x-default: TEST_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl

--- a/v2.0.yml
+++ b/v2.0.yml
@@ -1861,7 +1861,6 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
-    x-default: TEST_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl

--- a/v2.1-client.yml
+++ b/v2.1-client.yml
@@ -2428,7 +2428,6 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
-    x-default: TEST_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl

--- a/v2.1-events.yml
+++ b/v2.1-events.yml
@@ -1225,7 +1225,6 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
-    x-default: TEST_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl

--- a/v2.1.yml
+++ b/v2.1.yml
@@ -1994,7 +1994,6 @@ securityDefinitions:
     flow: accessCode
     tokenUrl: https://clever.com/oauth/tokens
     type: oauth2
-    x-default: TEST_TOKEN
 swagger: "2.0"
 x-samples-languages:
 - curl


### PR DESCRIPTION
ReadMe changed the way they interpreted our swagger file such that if we have a token defined for test purposes, users can't enter their own token to try out.

So we're removing the test token.