### PR TITLE
Update schema to align with v3 spec

### DIFF
--- a/v3.0.yml
+++ b/v3.0.yml
@@ -1,5 +1,14 @@
 basePath: /v3.0
 definitions:
+  AdminName:
+    properties:
+      first:
+        type: string
+        x-nullable: true
+      last:
+        type: string
+        x-nullable: true
+    type: object
   BadRequest:
     properties:
       message:
@@ -7,7 +16,7 @@ definitions:
     type: object
   Contact:
     properties:
-      legacy_id:
+      id:
         type: string
         x-validation: true
       phone:
@@ -23,6 +32,18 @@ definitions:
         type: string
         x-nullable: true
         x-validation: true
+      relationship:
+        enum:
+        - Parent
+        - Grandparent
+        - Self
+        - Aunt/Uncle
+        - Sibling
+        - Other
+        - ""
+        type: string
+        x-nullable: true
+        x-validation: true
       sis_id:
         type: string
         x-nullable: true
@@ -30,6 +51,23 @@ definitions:
         items:
           $ref: '#/definitions/StudentRelationship'
         type: array
+        x-validation: true
+      students:
+        items:
+          type: string
+        type: array
+        x-validation: true
+      type:
+        enum:
+        - Parent/Guardian
+        - Emergency
+        - Primary
+        - Secondary
+        - Family
+        - Other
+        - ""
+        type: string
+        x-nullable: true
         x-validation: true
     type: object
   Course:
@@ -71,7 +109,8 @@ definitions:
   District:
     properties:
       district_contact:
-        type: string
+        $ref: '#/definitions/DistrictAdmin'
+        x-nullable: true
         x-validation: true
       error:
         type: string
@@ -129,7 +168,7 @@ definitions:
     type: object
   DistrictAdmin:
     properties:
-      legacy_id:
+      id:
         type: string
         x-validation: true
       title:
@@ -504,7 +543,7 @@ definitions:
         x-nullable: true
       ext:
         type: object
-      legacy_id:
+      id:
         type: string
         x-validation: true
       roles:
@@ -599,7 +638,7 @@ definitions:
         type: string
         x-nullable: true
         x-validation: true
-      legacy_id:
+      id:
         type: string
         x-validation: true
       last_modified:
@@ -681,9 +720,12 @@ definitions:
       district:
         type: string
         x-validation: true
+      email:
+        type: string
+        x-nullable: true
       ext:
         type: object
-      legacy_id:
+      id:
         type: string
         x-validation: true
       last_modified:
@@ -752,6 +794,9 @@ definitions:
     type: object
   User:
     properties:
+      contact:
+        $ref: '#/definitions/Contact'
+        x-nullable: true
       created:
         format: datetime
         type: string
@@ -759,6 +804,9 @@ definitions:
       district:
         type: string
         x-validation: true
+      district_admin:
+        $ref: '#/definitions/DistrictAdmin'
+        x-nullable: true
       email:
         type: string
         x-nullable: true
@@ -771,24 +819,15 @@ definitions:
         x-validation: true
       name:
         $ref: '#/definitions/Name'
-      roles:
-        type: object
-        additionalProperties:
-          contact:
-            $ref: '#/definitions/Contact'
-            x-nullable: true
-          district_admin:
-            $ref: '#/definitions/DistrictAdmin'
-            x-nullable: true
-          staff:
-            $ref: '#/definitions/Staff'
-            x-nullable: true
-          student:
-            $ref: '#/definitions/Student'
-            x-nullable: true
-          teacher:
-            $ref: '#/definitions/Teacher'
-            x-nullable: true
+      staff:
+        $ref: '#/definitions/Staff'
+        x-nullable: true
+      student:
+        $ref: '#/definitions/Student'
+        x-nullable: true
+      teacher:
+        $ref: '#/definitions/Teacher'
+        x-nullable: true
     type: object
   UserResponse:
     properties:
@@ -1101,11 +1140,12 @@ paths:
         required: true
         type: string
       - enum:
+        - contact
+        - staff
         - student
         - teacher
         in: query
         name: role
-        type: string
       - in: query
         name: limit
         type: integer
@@ -1694,7 +1734,7 @@ paths:
       - Users
   /users/{id}/mystudents:
     get:
-      description: Returns the student users for a teacher or contact user
+      description: Returns the student users for a teacher user
       operationId: getStudentsForUser
       parameters:
       - in: path

--- a/v3.0.yml
+++ b/v3.0.yml
@@ -1,14 +1,5 @@
 basePath: /v3.0
 definitions:
-  AdminName:
-    properties:
-      first:
-        type: string
-        x-nullable: true
-      last:
-        type: string
-        x-nullable: true
-    type: object
   BadRequest:
     properties:
       message:
@@ -16,7 +7,7 @@ definitions:
     type: object
   Contact:
     properties:
-      id:
+      legacy_id:
         type: string
         x-validation: true
       phone:
@@ -32,18 +23,6 @@ definitions:
         type: string
         x-nullable: true
         x-validation: true
-      relationship:
-        enum:
-        - Parent
-        - Grandparent
-        - Self
-        - Aunt/Uncle
-        - Sibling
-        - Other
-        - ""
-        type: string
-        x-nullable: true
-        x-validation: true
       sis_id:
         type: string
         x-nullable: true
@@ -51,23 +30,6 @@ definitions:
         items:
           $ref: '#/definitions/StudentRelationship'
         type: array
-        x-validation: true
-      students:
-        items:
-          type: string
-        type: array
-        x-validation: true
-      type:
-        enum:
-        - Parent/Guardian
-        - Emergency
-        - Primary
-        - Secondary
-        - Family
-        - Other
-        - ""
-        type: string
-        x-nullable: true
         x-validation: true
     type: object
   Course:
@@ -109,8 +71,7 @@ definitions:
   District:
     properties:
       district_contact:
-        $ref: '#/definitions/DistrictAdmin'
-        x-nullable: true
+        type: string
         x-validation: true
       error:
         type: string
@@ -168,7 +129,7 @@ definitions:
     type: object
   DistrictAdmin:
     properties:
-      id:
+      legacy_id:
         type: string
         x-validation: true
       title:
@@ -543,7 +504,7 @@ definitions:
         x-nullable: true
       ext:
         type: object
-      id:
+      legacy_id:
         type: string
         x-validation: true
       roles:
@@ -638,7 +599,7 @@ definitions:
         type: string
         x-nullable: true
         x-validation: true
-      id:
+      legacy_id:
         type: string
         x-validation: true
       last_modified:
@@ -720,12 +681,9 @@ definitions:
       district:
         type: string
         x-validation: true
-      email:
-        type: string
-        x-nullable: true
       ext:
         type: object
-      id:
+      legacy_id:
         type: string
         x-validation: true
       last_modified:
@@ -794,9 +752,6 @@ definitions:
     type: object
   User:
     properties:
-      contact:
-        $ref: '#/definitions/Contact'
-        x-nullable: true
       created:
         format: datetime
         type: string
@@ -804,9 +759,6 @@ definitions:
       district:
         type: string
         x-validation: true
-      district_admin:
-        $ref: '#/definitions/DistrictAdmin'
-        x-nullable: true
       email:
         type: string
         x-nullable: true
@@ -819,15 +771,24 @@ definitions:
         x-validation: true
       name:
         $ref: '#/definitions/Name'
-      staff:
-        $ref: '#/definitions/Staff'
-        x-nullable: true
-      student:
-        $ref: '#/definitions/Student'
-        x-nullable: true
-      teacher:
-        $ref: '#/definitions/Teacher'
-        x-nullable: true
+      roles:
+        type: object
+        additionalProperties:
+          contact:
+            $ref: '#/definitions/Contact'
+            x-nullable: true
+          district_admin:
+            $ref: '#/definitions/DistrictAdmin'
+            x-nullable: true
+          staff:
+            $ref: '#/definitions/Staff'
+            x-nullable: true
+          student:
+            $ref: '#/definitions/Student'
+            x-nullable: true
+          teacher:
+            $ref: '#/definitions/Teacher'
+            x-nullable: true
     type: object
   UserResponse:
     properties:
@@ -1140,8 +1101,6 @@ paths:
         required: true
         type: string
       - enum:
-        - contact
-        - staff
         - student
         - teacher
         in: query
@@ -1735,7 +1694,7 @@ paths:
       - Users
   /users/{id}/mystudents:
     get:
-      description: Returns the student users for a teacher user
+      description: Returns the student users for a teacher or contact user
       operationId: getStudentsForUser
       parameters:
       - in: path


### PR DESCRIPTION
- [x] Meta: district's district contact should become a user ID instead of a district admin object.
	- [x] Update District/properties/district_contact to `type: string` `x-validation: true`
- [x] Add `type` to resources/{id}/users/get/parameters/1
- [x] Remove `relationship`, `students`, and `type` from Contact properties
- [x] Remove AdminName definition because this is not referenced?
- [x] Remove `email` from Teacher
- [x] In user definitions, rename `id` to `legacy_id` for 
	- [x] Contact, 
	- [x] DistrictAdmin, 
	- [x] Staff, 
	- [x] Student, 
	- [x] Teacher
- [x] Change Users field per role to single role field with list of roles
- [x] Remove `contact`, `staff` from /resources/{id}/users/get/parameters/1
- [x] Change description for /users/{id}/mystudents to "Returns the student users for a teacher or contact user"