### PR TITLE
SYNC-2075 More edits

### DIFF
--- a/full-v3.yml
+++ b/full-v3.yml
@@ -321,7 +321,7 @@ paths:
   /resources/{id}/users:
     get:
       tags: ["Resources"]
-      description: Returns the contact, staff, student and/or teacher users for a resource
+      description: Returns the student and/or teacher users for a resource
       operationId: getUsersForResource
       parameters:
       - in: path
@@ -331,8 +331,6 @@ paths:
       - in: query
         name: role
         enum:
-        - "contact"
-        - "staff"
         - "student"
         - "teacher"
       - in: query
@@ -923,7 +921,7 @@ paths:
   /users/{id}/mystudents:
     get:
       tags: ["Users"]
-      description: Returns the student users for a teacher user
+      description: Returns the student users for a teacher or contact user
       operationId: getStudentsForUser
       parameters:
       - in: path
@@ -1270,16 +1268,6 @@ definitions:
       data:
         $ref: "#/definitions/User"
 
-  AdminName:
-    type: object
-    properties:
-      first:
-        type: string
-        x-nullable: true
-      last:
-        type: string
-        x-nullable: true
-
   Course:
     type: object
     properties:
@@ -1359,8 +1347,7 @@ definitions:
         items:
           type: string
       district_contact:
-        $ref: "#/definitions/DistrictAdmin"
-        x-nullable: true
+        type: string
         x-validation: true
 
   Location:
@@ -1701,7 +1688,7 @@ definitions:
   Contact:
     type: object
     properties:
-      id:
+      legacy_id:
         type: string
         x-validation: true
       phone:
@@ -1717,18 +1704,6 @@ definitions:
         - Work
         - Other
         - ""
-      relationship:
-        type: string
-        x-nullable: true
-        x-validation: true
-        enum:
-        - "Parent"
-        - "Grandparent"
-        - "Self"
-        - "Aunt/Uncle"
-        - "Sibling"
-        - "Other"
-        - ""
       sis_id:
         type: string
         x-nullable: true
@@ -1737,28 +1712,11 @@ definitions:
         x-validation: true
         items:
           $ref: "#/definitions/StudentRelationship"
-      students:
-        type: array
-        x-validation: true
-        items:
-          type: string
-      type:
-        type: string
-        x-nullable: true
-        x-validation: true
-        enum:
-        - "Parent/Guardian"
-        - "Emergency"
-        - "Primary"
-        - "Secondary"
-        - "Family"
-        - "Other"
-        - ""
 
   DistrictAdmin:
     type: object
     properties:
-      id:
+      legacy_id:
         type: string
         x-validation: true
       title:
@@ -1768,7 +1726,7 @@ definitions:
   Staff:
     type: object
     properties:
-      id:
+      legacy_id:
         type: string
         x-validation: true
       credentials:
@@ -1797,7 +1755,7 @@ definitions:
   Student:
     type: object
     properties:
-      id:
+      legacy_id:
         type: string
         x-validation: true
       created:
@@ -1976,7 +1934,7 @@ definitions:
   Teacher:
     type: object
     properties:
-      id:
+      legacy_id:
         type: string
         x-validation: true
       created:
@@ -1989,9 +1947,6 @@ definitions:
       district:
         type: string
         x-validation: true
-      email:
-        type: string
-        x-nullable: true
       last_modified:
         type: string
         format: datetime
@@ -2042,21 +1997,24 @@ definitions:
         x-validation: true
       name:
         $ref: "#/definitions/Name"
-      contact:
-        $ref: "#/definitions/Contact"
-        x-nullable: true
-      district_admin:
-        $ref: "#/definitions/DistrictAdmin"
-        x-nullable: true
-      staff:
-        $ref: "#/definitions/Staff"
-        x-nullable: true
-      student:
-        $ref: "#/definitions/Student"
-        x-nullable: true
-      teacher:
-        $ref: "#/definitions/Teacher"
-        x-nullable: true
+      roles:
+        type: object
+        additionalProperties:
+          contact:
+            $ref: '#/definitions/Contact'
+            x-nullable: true
+          district_admin:
+            $ref: '#/definitions/DistrictAdmin'
+            x-nullable: true
+          staff:
+            $ref: '#/definitions/Staff'
+            x-nullable: true
+          student:
+            $ref: '#/definitions/Student'
+            x-nullable: true
+          teacher:
+            $ref: '#/definitions/Teacher'
+            x-nullable: true
 
   CourseObject:
     type: object

--- a/v3.0-client.yml
+++ b/v3.0-client.yml
@@ -1,14 +1,5 @@
 basePath: /v3.0
 definitions:
-  AdminName:
-    properties:
-      first:
-        type: string
-        x-nullable: true
-      last:
-        type: string
-        x-nullable: true
-    type: object
   BadRequest:
     properties:
       message:
@@ -16,7 +7,7 @@ definitions:
     type: object
   Contact:
     properties:
-      id:
+      legacy_id:
         type: string
         x-validation: true
       phone:
@@ -32,18 +23,6 @@ definitions:
         type: string
         x-nullable: true
         x-validation: true
-      relationship:
-        enum:
-        - Parent
-        - Grandparent
-        - Self
-        - Aunt/Uncle
-        - Sibling
-        - Other
-        - ""
-        type: string
-        x-nullable: true
-        x-validation: true
       sis_id:
         type: string
         x-nullable: true
@@ -51,23 +30,6 @@ definitions:
         items:
           $ref: '#/definitions/StudentRelationship'
         type: array
-        x-validation: true
-      students:
-        items:
-          type: string
-        type: array
-        x-validation: true
-      type:
-        enum:
-        - Parent/Guardian
-        - Emergency
-        - Primary
-        - Secondary
-        - Family
-        - Other
-        - ""
-        type: string
-        x-nullable: true
         x-validation: true
     type: object
   Course:
@@ -114,8 +76,7 @@ definitions:
   District:
     properties:
       district_contact:
-        $ref: '#/definitions/DistrictAdmin'
-        x-nullable: true
+        type: string
         x-validation: true
       error:
         type: string
@@ -173,7 +134,7 @@ definitions:
     type: object
   DistrictAdmin:
     properties:
-      id:
+      legacy_id:
         type: string
         x-validation: true
       title:
@@ -600,7 +561,7 @@ definitions:
         x-nullable: true
       ext:
         type: object
-      id:
+      legacy_id:
         type: string
         x-validation: true
       roles:
@@ -748,14 +709,14 @@ definitions:
         type: string
         x-nullable: true
         x-validation: true
-      id:
-        type: string
-        x-validation: true
       iep_status:
         type: string
         x-nullable: true
       last_modified:
         format: datetime
+        type: string
+        x-validation: true
+      legacy_id:
         type: string
         x-validation: true
       location:
@@ -839,16 +800,13 @@ definitions:
       district:
         type: string
         x-validation: true
-      email:
-        type: string
-        x-nullable: true
       ext:
         type: object
-      id:
-        type: string
-        x-validation: true
       last_modified:
         format: datetime
+        type: string
+        x-validation: true
+      legacy_id:
         type: string
         x-validation: true
       name:
@@ -918,9 +876,6 @@ definitions:
     type: object
   User:
     properties:
-      contact:
-        $ref: '#/definitions/Contact'
-        x-nullable: true
       created:
         format: datetime
         type: string
@@ -928,9 +883,6 @@ definitions:
       district:
         type: string
         x-validation: true
-      district_admin:
-        $ref: '#/definitions/DistrictAdmin'
-        x-nullable: true
       email:
         type: string
         x-nullable: true
@@ -943,15 +895,24 @@ definitions:
         x-validation: true
       name:
         $ref: '#/definitions/Name'
-      staff:
-        $ref: '#/definitions/Staff'
-        x-nullable: true
-      student:
-        $ref: '#/definitions/Student'
-        x-nullable: true
-      teacher:
-        $ref: '#/definitions/Teacher'
-        x-nullable: true
+      roles:
+        additionalProperties:
+          contact:
+            $ref: '#/definitions/Contact'
+            x-nullable: true
+          district_admin:
+            $ref: '#/definitions/DistrictAdmin'
+            x-nullable: true
+          staff:
+            $ref: '#/definitions/Staff'
+            x-nullable: true
+          student:
+            $ref: '#/definitions/Student'
+            x-nullable: true
+          teacher:
+            $ref: '#/definitions/Teacher'
+            x-nullable: true
+        type: object
     type: object
   UserObject:
     properties:
@@ -1479,7 +1440,7 @@ paths:
       - Data
   /resources/{id}/users:
     get:
-      description: Returns the contact, staff, student and/or teacher users for a resource
+      description: Returns the student and/or teacher users for a resource
       operationId: getUsersForResource
       parameters:
       - in: path
@@ -1487,8 +1448,6 @@ paths:
         required: true
         type: string
       - enum:
-        - contact
-        - staff
         - student
         - teacher
         in: query
@@ -2081,7 +2040,7 @@ paths:
       - Data
   /users/{id}/mystudents:
     get:
-      description: Returns the student users for a teacher user
+      description: Returns the student users for a teacher or contact user
       operationId: getStudentsForUser
       parameters:
       - in: path

--- a/v3.0-events.yml
+++ b/v3.0-events.yml
@@ -1,14 +1,5 @@
 basePath: /v3.0
 definitions:
-  AdminName:
-    properties:
-      first:
-        type: string
-        x-nullable: true
-      last:
-        type: string
-        x-nullable: true
-    type: object
   BadRequest:
     properties:
       message:
@@ -16,7 +7,7 @@ definitions:
     type: object
   Contact:
     properties:
-      id:
+      legacy_id:
         type: string
         x-validation: true
       phone:
@@ -32,18 +23,6 @@ definitions:
         type: string
         x-nullable: true
         x-validation: true
-      relationship:
-        enum:
-        - Parent
-        - Grandparent
-        - Self
-        - Aunt/Uncle
-        - Sibling
-        - Other
-        - ""
-        type: string
-        x-nullable: true
-        x-validation: true
       sis_id:
         type: string
         x-nullable: true
@@ -51,23 +30,6 @@ definitions:
         items:
           $ref: '#/definitions/StudentRelationship'
         type: array
-        x-validation: true
-      students:
-        items:
-          type: string
-        type: array
-        x-validation: true
-      type:
-        enum:
-        - Parent/Guardian
-        - Emergency
-        - Primary
-        - Secondary
-        - Family
-        - Other
-        - ""
-        type: string
-        x-nullable: true
         x-validation: true
     type: object
   Course:
@@ -114,8 +76,7 @@ definitions:
   District:
     properties:
       district_contact:
-        $ref: '#/definitions/DistrictAdmin'
-        x-nullable: true
+        type: string
         x-validation: true
       error:
         type: string
@@ -173,7 +134,7 @@ definitions:
     type: object
   DistrictAdmin:
     properties:
-      id:
+      legacy_id:
         type: string
         x-validation: true
       title:
@@ -600,7 +561,7 @@ definitions:
         x-nullable: true
       ext:
         type: object
-      id:
+      legacy_id:
         type: string
         x-validation: true
       roles:
@@ -695,11 +656,11 @@ definitions:
         type: string
         x-nullable: true
         x-validation: true
-      id:
-        type: string
-        x-validation: true
       last_modified:
         format: datetime
+        type: string
+        x-validation: true
+      legacy_id:
         type: string
         x-validation: true
       location:
@@ -777,16 +738,13 @@ definitions:
       district:
         type: string
         x-validation: true
-      email:
-        type: string
-        x-nullable: true
       ext:
         type: object
-      id:
-        type: string
-        x-validation: true
       last_modified:
         format: datetime
+        type: string
+        x-validation: true
+      legacy_id:
         type: string
         x-validation: true
       name:
@@ -856,9 +814,6 @@ definitions:
     type: object
   User:
     properties:
-      contact:
-        $ref: '#/definitions/Contact'
-        x-nullable: true
       created:
         format: datetime
         type: string
@@ -866,9 +821,6 @@ definitions:
       district:
         type: string
         x-validation: true
-      district_admin:
-        $ref: '#/definitions/DistrictAdmin'
-        x-nullable: true
       email:
         type: string
         x-nullable: true
@@ -881,15 +833,24 @@ definitions:
         x-validation: true
       name:
         $ref: '#/definitions/Name'
-      staff:
-        $ref: '#/definitions/Staff'
-        x-nullable: true
-      student:
-        $ref: '#/definitions/Student'
-        x-nullable: true
-      teacher:
-        $ref: '#/definitions/Teacher'
-        x-nullable: true
+      roles:
+        additionalProperties:
+          contact:
+            $ref: '#/definitions/Contact'
+            x-nullable: true
+          district_admin:
+            $ref: '#/definitions/DistrictAdmin'
+            x-nullable: true
+          staff:
+            $ref: '#/definitions/Staff'
+            x-nullable: true
+          student:
+            $ref: '#/definitions/Student'
+            x-nullable: true
+          teacher:
+            $ref: '#/definitions/Teacher'
+            x-nullable: true
+        type: object
     type: object
   UserObject:
     properties:

--- a/v3.0.yml
+++ b/v3.0.yml
@@ -1,14 +1,5 @@
 basePath: /v3.0
 definitions:
-  AdminName:
-    properties:
-      first:
-        type: string
-        x-nullable: true
-      last:
-        type: string
-        x-nullable: true
-    type: object
   BadRequest:
     properties:
       message:
@@ -16,7 +7,7 @@ definitions:
     type: object
   Contact:
     properties:
-      id:
+      legacy_id:
         type: string
         x-validation: true
       phone:
@@ -32,18 +23,6 @@ definitions:
         type: string
         x-nullable: true
         x-validation: true
-      relationship:
-        enum:
-        - Parent
-        - Grandparent
-        - Self
-        - Aunt/Uncle
-        - Sibling
-        - Other
-        - ""
-        type: string
-        x-nullable: true
-        x-validation: true
       sis_id:
         type: string
         x-nullable: true
@@ -51,23 +30,6 @@ definitions:
         items:
           $ref: '#/definitions/StudentRelationship'
         type: array
-        x-validation: true
-      students:
-        items:
-          type: string
-        type: array
-        x-validation: true
-      type:
-        enum:
-        - Parent/Guardian
-        - Emergency
-        - Primary
-        - Secondary
-        - Family
-        - Other
-        - ""
-        type: string
-        x-nullable: true
         x-validation: true
     type: object
   Course:
@@ -109,8 +71,7 @@ definitions:
   District:
     properties:
       district_contact:
-        $ref: '#/definitions/DistrictAdmin'
-        x-nullable: true
+        type: string
         x-validation: true
       error:
         type: string
@@ -168,7 +129,7 @@ definitions:
     type: object
   DistrictAdmin:
     properties:
-      id:
+      legacy_id:
         type: string
         x-validation: true
       title:
@@ -543,7 +504,7 @@ definitions:
         x-nullable: true
       ext:
         type: object
-      id:
+      legacy_id:
         type: string
         x-validation: true
       roles:
@@ -638,11 +599,11 @@ definitions:
         type: string
         x-nullable: true
         x-validation: true
-      id:
-        type: string
-        x-validation: true
       last_modified:
         format: datetime
+        type: string
+        x-validation: true
+      legacy_id:
         type: string
         x-validation: true
       location:
@@ -720,16 +681,13 @@ definitions:
       district:
         type: string
         x-validation: true
-      email:
-        type: string
-        x-nullable: true
       ext:
         type: object
-      id:
-        type: string
-        x-validation: true
       last_modified:
         format: datetime
+        type: string
+        x-validation: true
+      legacy_id:
         type: string
         x-validation: true
       name:
@@ -794,9 +752,6 @@ definitions:
     type: object
   User:
     properties:
-      contact:
-        $ref: '#/definitions/Contact'
-        x-nullable: true
       created:
         format: datetime
         type: string
@@ -804,9 +759,6 @@ definitions:
       district:
         type: string
         x-validation: true
-      district_admin:
-        $ref: '#/definitions/DistrictAdmin'
-        x-nullable: true
       email:
         type: string
         x-nullable: true
@@ -819,15 +771,24 @@ definitions:
         x-validation: true
       name:
         $ref: '#/definitions/Name'
-      staff:
-        $ref: '#/definitions/Staff'
-        x-nullable: true
-      student:
-        $ref: '#/definitions/Student'
-        x-nullable: true
-      teacher:
-        $ref: '#/definitions/Teacher'
-        x-nullable: true
+      roles:
+        additionalProperties:
+          contact:
+            $ref: '#/definitions/Contact'
+            x-nullable: true
+          district_admin:
+            $ref: '#/definitions/DistrictAdmin'
+            x-nullable: true
+          staff:
+            $ref: '#/definitions/Staff'
+            x-nullable: true
+          student:
+            $ref: '#/definitions/Student'
+            x-nullable: true
+          teacher:
+            $ref: '#/definitions/Teacher'
+            x-nullable: true
+        type: object
     type: object
   UserResponse:
     properties:
@@ -1132,7 +1093,7 @@ paths:
       - Resources
   /resources/{id}/users:
     get:
-      description: Returns the contact, staff, student and/or teacher users for a resource
+      description: Returns the student and/or teacher users for a resource
       operationId: getUsersForResource
       parameters:
       - in: path
@@ -1140,13 +1101,10 @@ paths:
         required: true
         type: string
       - enum:
-        - contact
-        - staff
         - student
         - teacher
         in: query
         name: role
-        type: string
       - in: query
         name: limit
         type: integer
@@ -1735,7 +1693,7 @@ paths:
       - Users
   /users/{id}/mystudents:
     get:
-      description: Returns the student users for a teacher user
+      description: Returns the student users for a teacher or contact user
       operationId: getStudentsForUser
       parameters:
       - in: path


### PR DESCRIPTION
See https://github.com/Clever/swagger-api/pull/47 for set of files to change.
[SYNC-2075](https://clever.atlassian.net/browse/SYNC-2075)
[Schema in AirTable](https://airtable.com/shrKQIwNyoePcyhLI/tblDdFhpF7OYenIFQ/viwL8AYq8xjmOcrex?blocks=hide)

- [x] Meta: district's district contact should become a user ID instead of a district admin object.
	- [x] Update District/properties/district_contact to `type: string` `x-validation: true`
- [x] Add `type` to resources/{id}/users/get/parameters/1
- [x] Remove `relationship`, `students`, and `type` from Contact properties
- [x] Remove AdminName definition because this is not referenced?
- [x] Remove `email` from Teacher
- [x] In user definitions, rename `id` to `legacy_id` for 
	- [x] Contact, 
	- [x] DistrictAdmin, 
	- [x] Staff, 
	- [x] Student, 
	- [x] Teacher
- [x] Change Users field per role to single role field with list of roles
- [x] Remove `contact`, `staff` from /resources/{id}/users/get/parameters/1
- [x] Change description for /users/{id}/mystudents to "Returns the student users for a teacher or contact user"