### PR TITLE
Remove count param for /resources

### DIFF
--- a/full-v3.yml
+++ b/full-v3.yml
@@ -234,12 +234,6 @@ paths:
       - in: query
         name: ending_before
         type: string
-      - in: query
-        name: count
-        type: string
-        enum:
-        - ""
-        - "true"
       responses:
         '200':
           description: OK Response

--- a/v3.0-client.yml
+++ b/v3.0-client.yml
@@ -1354,12 +1354,6 @@ paths:
       - in: query
         name: ending_before
         type: string
-      - enum:
-        - ""
-        - "true"
-        in: query
-        name: count
-        type: string
       responses:
         "200":
           description: OK Response

--- a/v3.0.yml
+++ b/v3.0.yml
@@ -1007,12 +1007,6 @@ paths:
       - in: query
         name: ending_before
         type: string
-      - enum:
-        - ""
-        - "true"
-        in: query
-        name: count
-        type: string
       responses:
         "200":
           description: OK Response


### PR DESCRIPTION
Removing the `count` parameter for `/resources` because we don't support it.