### PR TITLE
Dob

### DIFF
--- a/full-v1.yml
+++ b/full-v1.yml
@@ -1383,7 +1383,7 @@ definitions:
         x-validation: true
       dob:
         type: string
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         x-nullable: true
         x-validation: true
       ell_status:

--- a/full-v2.yml
+++ b/full-v2.yml
@@ -1466,7 +1466,7 @@ definitions:
         x-validation: true
       dob:
         type: string
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         x-nullable: true
         x-validation: true
       ell_status:

--- a/full-v3.yml
+++ b/full-v3.yml
@@ -1797,7 +1797,7 @@ definitions:
         $ref: "#/definitions/Credentials"
       dob:
         type: string
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         x-nullable: true
         x-validation: true
       ell_status:

--- a/v1.1-events.yml
+++ b/v1.1-events.yml
@@ -417,7 +417,7 @@ definitions:
         type: string
         x-validation: true
       dob:
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         type: string
         x-nullable: true
         x-validation: true

--- a/v1.1.yml
+++ b/v1.1.yml
@@ -405,7 +405,7 @@ definitions:
         type: string
         x-validation: true
       dob:
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         type: string
         x-nullable: true
         x-validation: true

--- a/v1.2-client.yml
+++ b/v1.2-client.yml
@@ -466,7 +466,7 @@ definitions:
         type: string
         x-validation: true
       dob:
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         type: string
         x-nullable: true
         x-validation: true

--- a/v1.2-events.yml
+++ b/v1.2-events.yml
@@ -432,7 +432,7 @@ definitions:
         type: string
         x-validation: true
       dob:
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         type: string
         x-nullable: true
         x-validation: true

--- a/v1.2.yml
+++ b/v1.2.yml
@@ -420,7 +420,7 @@ definitions:
         type: string
         x-validation: true
       dob:
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         type: string
         x-nullable: true
         x-validation: true

--- a/v2.0-events.yml
+++ b/v2.0-events.yml
@@ -604,7 +604,7 @@ definitions:
         type: string
         x-validation: true
       dob:
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         type: string
         x-nullable: true
         x-validation: true

--- a/v2.0-events.yml
+++ b/v2.0-events.yml
@@ -177,6 +177,7 @@ definitions:
         - pending
         - error
         - paused
+        - success
         type: string
         x-validation: true
     type: object

--- a/v2.0.yml
+++ b/v2.0.yml
@@ -167,6 +167,7 @@ definitions:
         - pending
         - error
         - paused
+        - success
         type: string
         x-validation: true
     type: object

--- a/v2.0.yml
+++ b/v2.0.yml
@@ -537,7 +537,7 @@ definitions:
         type: string
         x-validation: true
       dob:
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         type: string
         x-nullable: true
         x-validation: true

--- a/v2.1-client.yml
+++ b/v2.1-client.yml
@@ -661,7 +661,7 @@ definitions:
         type: string
         x-validation: true
       dob:
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         type: string
         x-nullable: true
         x-validation: true

--- a/v2.1-client.yml
+++ b/v2.1-client.yml
@@ -190,6 +190,7 @@ definitions:
         - error
         - paused
         - ""
+        - success
         type: string
         x-nullable: true
         x-validation: true

--- a/v2.1-events.yml
+++ b/v2.1-events.yml
@@ -661,7 +661,7 @@ definitions:
         type: string
         x-validation: true
       dob:
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         type: string
         x-nullable: true
         x-validation: true

--- a/v2.1-events.yml
+++ b/v2.1-events.yml
@@ -190,6 +190,7 @@ definitions:
         - error
         - paused
         - ""
+        - success
         type: string
         x-nullable: true
         x-validation: true

--- a/v2.1.yml
+++ b/v2.1.yml
@@ -180,6 +180,7 @@ definitions:
         - error
         - paused
         - ""
+        - success
         type: string
         x-nullable: true
         x-validation: true

--- a/v2.1.yml
+++ b/v2.1.yml
@@ -594,7 +594,7 @@ definitions:
         type: string
         x-validation: true
       dob:
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         type: string
         x-nullable: true
         x-validation: true

--- a/v3.0-client.yml
+++ b/v3.0-client.yml
@@ -606,7 +606,7 @@ definitions:
       credentials:
         $ref: '#/definitions/Credentials'
       dob:
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         type: string
         x-nullable: true
         x-validation: true

--- a/v3.0-events.yml
+++ b/v3.0-events.yml
@@ -606,7 +606,7 @@ definitions:
       credentials:
         $ref: '#/definitions/Credentials'
       dob:
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         type: string
         x-nullable: true
         x-validation: true

--- a/v3.0.yml
+++ b/v3.0.yml
@@ -549,7 +549,7 @@ definitions:
       credentials:
         $ref: '#/definitions/Credentials'
       dob:
-        format: datetime
+        pattern: (?:[0-9]{1,2})/([0-9]{1,2})/([0-9]{4})
         type: string
         x-nullable: true
         x-validation: true


### PR DESCRIPTION
For strongly typed languages like Go our DOB field format (mm/dd/yy) does not conform to the RFC-3339 spec.

This means anyone who generates a client from the swagger file in a strongly typed lanaged as-is will see errors when trying to parse/validate the dob field.

This PR adds regular expression validation to the swagger spec instead of using datetime format (which was wrong).

Also generated some changes made in PR #44 which were only made in the base file.