### PR TITLE
Fix markdown formatting in README.md#Custom Swagger Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Update the source yml (full-vX.yml) and run `make generate VERSION=3` (for any v
 
 ## Custom Swagger Extensions
 
-x-samples-languages: controls the sample languges in the Clever API explorer
-x-nullable: indicates that a object property is optional
-x-validation: indicates that Clever has validated the fields meets the specified format
+x-samples-languages: controls the sample languages in the Clever API explorer  
+x-nullable: indicates that a object property is optional  
+x-validation: indicates that Clever has validated the fields meets the specified format  


### PR DESCRIPTION
Fixes [line breaks](https://www.markdownguide.org/basic-syntax/#line-break-best-practices) (external link to markdownguide.org) and a typo in `README.md`.

