### PR TITLE
v3.1 schema update for LMS Connect endpoints

### DIFF
--- a/full-v3.yml
+++ b/full-v3.yml
@@ -1106,8 +1106,6 @@ paths:
           $ref: "#/responses/BadRequest"
         '401':
           $ref: "#/responses/Unauthorized"
-        '404':
-          $ref: '#/responses/NotFound'
 
   /sections/{section_id}/assignments/{assignment_id}:
     get:

--- a/full-v3.yml
+++ b/full-v3.yml
@@ -35,6 +35,11 @@ responses:
     schema:
       $ref: "#/definitions/NotFound"
 
+  Unauthorized:
+    description: Not authorized
+    schema:
+      $ref: "#/definitions/Unauthorized"
+
 security:
   - oauth: []
 
@@ -1075,6 +1080,212 @@ paths:
         '404':
           $ref: '#/responses/NotFound'
 
+  # LMS Connect endpoints
+  /sections/{section_id}/assignments:
+    post:
+      tags: ["Assignments"]
+      description: Creates a new assignment in the specified section
+      operationId: createAssignmentForSection
+      parameters:
+        - name: section_id
+          in: path
+          type: string
+          format: mongo-id
+          required: true
+        - name: assignmentRequestBody
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/AssignmentRequest"
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: "#/definitions/AssignmentResponse"
+        '400':
+          $ref: "#/responses/BadRequest"
+        '401':
+          $ref: "#/responses/Unauthorized"
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /sections/{section_id}/assignments/{assignment_id}:
+    get:
+      tags: ["Assignments"]
+      description: Returns a specific assignment for a section
+      operationId: getAssignmentForSection
+      parameters:
+        - name: section_id
+          in: path
+          type: string
+          format: mongo-id
+          required: true
+        - name: assignment_id
+          in: path
+          type: string
+          required: true
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: "#/definitions/AssignmentResponse"
+        '401':
+          $ref: "#/responses/Unauthorized"
+        '404':
+          $ref: '#/responses/NotFound'
+    patch:
+      tags: ["Assignments"]
+      description: Updates an existing assignment in the specified section
+      operationId: updateAssignmentForSection
+      parameters:
+        - name: section_id
+          in: path
+          type: string
+          format: mongo-id
+          required: true
+        - name: assignment_id
+          in: path
+          type: string
+          required: true
+        - name: assignmentRequestBody
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/AssignmentRequest"
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: "#/definitions/AssignmentResponse"
+        '401':
+          $ref: "#/responses/Unauthorized"
+        '404':
+          $ref: '#/responses/NotFound'
+        '400':
+          $ref: "#/responses/BadRequest"
+        '500':
+          $ref: "#/responses/InternalError"
+    delete:
+      tags: ["Assignments"]
+      description: Deletes an existing assignment in the specified section
+      operationId: deleteAssignmentForSection
+      parameters:
+        - name: section_id
+          in: path
+          type: string
+          format: mongo-id
+          required: true
+        - name: assignment_id
+          in: path
+          type: string
+          required: true
+      responses:
+        '200':
+          description: OK Response
+        '401':
+          $ref: "#/responses/Unauthorized"
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /sections/{section_id}/assignments/{assignment_id}/submissions:
+    get:
+      tags: ["Assignments"]
+      description: Returns the submissions for an assignment.
+      operationId: getSubmissionsForAssignment
+      parameters:
+        - name: section_id
+          in: path
+          type: string
+          format: mongo-id
+          required: true
+        - name: assignment_id
+          in: path
+          type: string
+          required: true
+        - name: cursor
+          in: query
+          type: string
+        - name: limit
+          in: query
+          type: integer
+          minimum: 1
+          maximum: 100
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: "#/definitions/SubmissionsResponse"
+        '401':
+          $ref: "#/responses/Unauthorized"
+        '404':
+          $ref: '#/responses/NotFound'
+
+  /sections/{section_id}/assignments/{assignment_id}/submissions/{user_id}:
+    get:
+      tags: ["Submissions"]
+      description: Returns a specific user's submission for an assignment.
+      operationId: getSubmissionForAssignment
+      parameters:
+        - name: section_id
+          in: path
+          type: string
+          format: mongo-id
+          required: true
+        - name: assignment_id
+          in: path
+          type: string
+          required: true
+        - name: user_id
+          in: path
+          type: string
+          format: mongo-id
+          required: true
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: "#/definitions/SubmissionResponse"
+        '401':
+          $ref: "#/responses/Unauthorized"
+        '404':
+          $ref: '#/responses/NotFound'
+    patch:
+      tags: ["Submissions"]
+      description: Updates an existing submission in the specified assignment for a user.
+      operationId: updateSubmissionForAssignment
+      parameters:
+        - name: section_id
+          in: path
+          type: string
+          format: mongo-id
+          required: true
+        - name: assignment_id
+          in: path
+          type: string
+          required: true
+        - name: user_id
+          in: path
+          type: string
+          format: mongo-id
+          required: true
+        - name: submissionRequestBody
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/SubmissionRequest"
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: "#/definitions/SubmissionResponse"
+        '401':
+          $ref: "#/responses/Unauthorized"
+        '404':
+          $ref: '#/responses/NotFound'
+        '400':
+          $ref: "#/responses/BadRequest"
+        '500':
+          $ref: "#/responses/InternalError"
 
   /events:
     get:
@@ -1141,6 +1352,12 @@ definitions:
         type: string
 
   InternalError:
+    type: object
+    properties:
+      message:
+        type: string
+
+  Unauthorized:
     type: object
     properties:
       message:
@@ -1365,6 +1582,16 @@ definitions:
       id:
         type: string
         x-validation: true
+      lms_state:
+        type: string
+        x-nullable: true
+        x-validation: true
+        enum:
+        - "matching_in_progress"
+        - "error"
+        - "disconnected"
+        - ""
+        - "success"
       name:
         type: string
       mdr_number:
@@ -2193,6 +2420,373 @@ definitions:
     properties:
       object:
         $ref: "#/definitions/User"
+
+  Assignment:
+    type: object
+    properties:
+      id:
+        type: string
+      created:
+        type: string
+        format: datetime
+        x-nullable: true
+      last_modified:
+        type: string
+        format: datetime
+        x-nullable: true
+      description:
+        type: string
+      due_date:
+        type: string
+        format: datetime
+        x-nullable: true
+      grading_type:
+        $ref: "#/definitions/GradingType"
+      state:
+        $ref: "#/definitions/AssignmentState"
+      title:
+        type: string
+      assignee_ids:
+        type: array
+        items:
+          type: string
+        x-omitempty: true
+      assignee_mode:
+        $ref: "#/definitions/AssigneeMode"
+        x-nullable: true
+      attachments:
+        type: array
+        items:
+          $ref: "#/definitions/Attachment"
+        x-omitempty: true
+      category_id:
+        type: string
+        x-nullable: true
+      description_plaintext:
+        type: string
+        x-nullable: true
+      display_date:
+        type: string
+        format: datetime
+        x-nullable: true
+      end_date:
+        type: string
+        format: datetime
+        x-nullable: true
+      grading_scale:
+        type: array
+        items:
+          $ref: "#/definitions/GradingScale"
+        x-omitempty: true
+      max_attempts:
+        type: integer
+        x-omitempty: true
+      points_possible:
+        type: number
+        format: float
+        x-nullable: true
+      start_date:
+        type: string
+        format: datetime
+        x-nullable: true
+      submission_types:
+        type: array
+        items:
+          $ref: "#/definitions/SubmissionType"
+        x-omitempty: true
+      term_id:
+        type: string
+        x-nullable: true
+
+  Submission:
+    type: object
+    properties:
+      id:
+        type: string
+      created:
+        type: string
+        format: datetime
+        x-nullable: true
+      assignment_id:
+        type: string
+      state:
+        $ref: "#/definitions/SubmissionState"
+      user_id:
+        type: string
+      attachments:
+        type: array
+        items:
+          $ref: "#/definitions/Attachment"
+        x-omitempty: true
+      extra_attempts:
+        type: integer
+        x-omitempty: true
+      flags:
+        type: array
+        items:
+          $ref: "#/definitions/SubmissionFlag"
+        x-omitempty: true
+      grade:
+        type: string
+        x-nullable: true
+      grade_comment:
+        type: string
+        x-nullable: true
+      grade_points:
+        type: number
+        format: float
+        x-omitempty: true
+      grader_id:
+        type: string
+        x-nullable: true
+      last_modified:
+        type: string
+        format: datetime
+        x-nullable: true
+      override_due_date:
+        type: string
+        format: datetime
+        x-nullable: true
+
+  AssigneeMode:
+    type: string
+    enum:
+        - all
+        - individuals
+
+  AssignmentState:
+    type: string
+    enum:
+        - draft
+        - scheduled
+        - open
+        - locked
+
+  Attachment:
+    type: object
+    properties:
+      type:
+        type: string
+      title:
+        type: string
+        x-nullable: true
+      description:
+        type: string
+        x-nullable: true
+      file_external_id:
+        type: string
+        x-nullable: true
+      size:
+        type: number
+        format: float
+        x-omitempty: true
+      thumbnail_url:
+        type: string
+        x-nullable: true
+      url:
+        type: string
+        x-nullable: true
+
+  GradingScale:
+    type: object
+    properties:
+      name:
+        type: string
+      entries:
+        type: array
+        items:
+          $ref: "#/definitions/GradingScaleEntry"
+        x-nullable: true
+
+  GradingScaleEntry:
+    type: object
+    properties:
+      name:
+        type: string
+      value:
+        type: string
+
+  GradingType:
+    type: string
+    enum:
+      - points
+      - percent
+      - pass_fail
+      - letter_grade
+
+  SubmissionType:
+    type: string
+    enum:
+        - link
+        - file
+        - text
+        - discussion
+
+  SubmissionFlag:
+    type: string
+    enum:
+      - excused
+      - late
+      - missing
+
+  SubmissionState:
+    type: string
+    enum:
+      - created
+      - submitted
+      - returned
+      - reclaimed
+
+  AssignmentRequest:
+    type: object
+    properties:
+      # Required fields for create request
+      description:
+        type: string
+        x-nullable: true
+      due_date:
+        type: string
+        format: datetime
+        x-nullable: true
+      grading_type:
+        $ref: "#/definitions/GradingType"
+        x-nullable: true
+      points_possible:
+        type: number
+        format: float
+        x-nullable: true
+      title:
+        type: string
+        x-nullable: true
+      # Optional fields
+      assignee_ids:
+        type: array
+        items:
+          type: string
+        x-omitempty: true
+      assignee_mode:
+        $ref: "#/definitions/AssigneeMode"
+        x-nullable: true
+      attachments:
+        type: array
+        items:
+          $ref: "#/definitions/AttachmentRequest"
+        x-omitempty: true
+      description_plaintext:
+        type: string
+        x-nullable: true
+      display_date:
+        type: string
+        format: datetime
+        x-nullable: true
+      end_date:
+        type: string
+        format: datetime
+        x-nullable: true
+      max_attempts:
+        type: integer
+        x-omitempty: true
+      start_date:
+        type: string
+        format: datetime
+        x-nullable: true
+      submission_types:
+        type: array
+        items:
+          $ref: "#/definitions/SubmissionType"
+        x-omitempty: true
+      term_id:
+        type: string
+        x-nullable: true
+
+  AttachmentRequest:
+    type: object
+    properties:
+      type:
+        type: string
+        enum:
+        - file
+      title:
+        type: string
+        x-nullable: true
+      description:
+        type: string
+        x-nullable: true
+      url:
+        type: string
+        x-nullable: true
+
+  SubmissionRequest:
+    type: object
+    properties:
+      attachments:
+        type: array
+        items:
+          $ref: "#/definitions/AttachmentRequest"
+        x-omitempty: true
+      extra_attempts:
+        type: integer
+        x-omitempty: true
+      flags:
+        type: array
+        items:
+          $ref: "#/definitions/SubmissionFlag"
+        x-omitempty: true
+      grade:
+        type: string
+        x-nullable: true
+      grade_comment:
+        type: string
+        x-nullable: true
+      grade_points:
+        type: number
+        format: float
+        x-omitempty: true
+      grader_id:
+        type: string
+        x-nullable: true
+      override_due_date:
+        type: string
+        format: datetime
+        x-nullable: true
+      state:
+        $ref: "#/definitions/SubmissionState"
+        x-nullable: true
+
+  AssignmentResponse:
+    type: object
+    properties:
+      data:
+        $ref: "#/definitions/Assignment"
+
+  SubmissionResponse:
+    type: object
+    properties:
+      data:
+        $ref: "#/definitions/Submission"
+
+  SubmissionsResponse:
+    type: object
+    properties:
+      data:
+        type: array
+        items:
+          $ref: "#/definitions/Submission"
+      links:
+        x-omitempty: true
+        type: array
+        items:
+          $ref: "#/definitions/SubmissionsLink"
+
+  SubmissionsLink:
+    type: object
+    properties:
+      rel:
+        enum:
+          - next
+        type: string
+      uri:
+        type: string
 
   EventsResponse:
     type: object

--- a/v3.1-client.yml
+++ b/v3.1-client.yml
@@ -2515,8 +2515,6 @@ paths:
           $ref: '#/responses/BadRequest'
         "401":
           $ref: '#/responses/Unauthorized'
-        "404":
-          $ref: '#/responses/NotFound'
       tags:
       - LMS Connect
   /sections/{section_id}/assignments/{assignment_id}:

--- a/v3.1-client.yml
+++ b/v3.1-client.yml
@@ -1,5 +1,197 @@
 basePath: /v3.1
 definitions:
+  AssigneeMode:
+    enum:
+    - all
+    - individuals
+    type: string
+  Assignment:
+    properties:
+      assignee_ids:
+        items:
+          type: string
+        type: array
+        x-omitempty: true
+      assignee_mode:
+        $ref: '#/definitions/AssigneeMode'
+        x-nullable: true
+      attachments:
+        items:
+          $ref: '#/definitions/Attachment'
+        type: array
+        x-omitempty: true
+      category_id:
+        type: string
+        x-nullable: true
+      created:
+        format: datetime
+        type: string
+        x-nullable: true
+      description:
+        type: string
+      description_plaintext:
+        type: string
+        x-nullable: true
+      display_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      due_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      end_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      grading_scale:
+        items:
+          $ref: '#/definitions/GradingScale'
+        type: array
+        x-omitempty: true
+      grading_type:
+        $ref: '#/definitions/GradingType'
+      id:
+        type: string
+      last_modified:
+        format: datetime
+        type: string
+        x-nullable: true
+      max_attempts:
+        type: integer
+        x-omitempty: true
+      points_possible:
+        format: float
+        type: number
+        x-nullable: true
+      start_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      state:
+        $ref: '#/definitions/AssignmentState'
+      submission_types:
+        items:
+          $ref: '#/definitions/SubmissionType'
+        type: array
+        x-omitempty: true
+      term_id:
+        type: string
+        x-nullable: true
+      title:
+        type: string
+    type: object
+  AssignmentRequest:
+    properties:
+      assignee_ids:
+        items:
+          type: string
+        type: array
+        x-omitempty: true
+      assignee_mode:
+        $ref: '#/definitions/AssigneeMode'
+        x-nullable: true
+      attachments:
+        items:
+          $ref: '#/definitions/AttachmentRequest'
+        type: array
+        x-omitempty: true
+      description:
+        type: string
+        x-nullable: true
+      description_plaintext:
+        type: string
+        x-nullable: true
+      display_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      due_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      end_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      grading_type:
+        $ref: '#/definitions/GradingType'
+        x-nullable: true
+      max_attempts:
+        type: integer
+        x-omitempty: true
+      points_possible:
+        format: float
+        type: number
+        x-nullable: true
+      start_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      submission_types:
+        items:
+          $ref: '#/definitions/SubmissionType'
+        type: array
+        x-omitempty: true
+      term_id:
+        type: string
+        x-nullable: true
+      title:
+        type: string
+        x-nullable: true
+    type: object
+  AssignmentResponse:
+    properties:
+      data:
+        $ref: '#/definitions/Assignment'
+    type: object
+  AssignmentState:
+    enum:
+    - draft
+    - scheduled
+    - open
+    - locked
+    type: string
+  Attachment:
+    properties:
+      description:
+        type: string
+        x-nullable: true
+      file_external_id:
+        type: string
+        x-nullable: true
+      size:
+        format: float
+        type: number
+        x-omitempty: true
+      thumbnail_url:
+        type: string
+        x-nullable: true
+      title:
+        type: string
+        x-nullable: true
+      type:
+        type: string
+      url:
+        type: string
+        x-nullable: true
+    type: object
+  AttachmentRequest:
+    properties:
+      description:
+        type: string
+        x-nullable: true
+      title:
+        type: string
+        x-nullable: true
+      type:
+        enum:
+        - file
+        type: string
+      url:
+        type: string
+        x-nullable: true
+    type: object
   BadRequest:
     properties:
       message:
@@ -138,6 +330,16 @@ definitions:
         format: date
         type: string
         x-validation: true
+      lms_state:
+        enum:
+        - matching_in_progress
+        - error
+        - disconnected
+        - ""
+        - success
+        type: string
+        x-nullable: true
+        x-validation: true
       login_methods:
         items:
           type: string
@@ -257,6 +459,30 @@ definitions:
           $ref: '#/definitions/Link'
         type: array
     type: object
+  GradingScale:
+    properties:
+      entries:
+        items:
+          $ref: '#/definitions/GradingScaleEntry'
+        type: array
+        x-nullable: true
+      name:
+        type: string
+    type: object
+  GradingScaleEntry:
+    properties:
+      name:
+        type: string
+      value:
+        type: string
+    type: object
+  GradingType:
+    enum:
+    - points
+    - percent
+    - pass_fail
+    - letter_grade
+    type: string
   InternalError:
     properties:
       message:
@@ -1099,6 +1325,137 @@ definitions:
         x-nullable: true
         x-validation: true
     type: object
+  Submission:
+    properties:
+      assignment_id:
+        type: string
+      attachments:
+        items:
+          $ref: '#/definitions/Attachment'
+        type: array
+        x-omitempty: true
+      created:
+        format: datetime
+        type: string
+        x-nullable: true
+      extra_attempts:
+        type: integer
+        x-omitempty: true
+      flags:
+        items:
+          $ref: '#/definitions/SubmissionFlag'
+        type: array
+        x-omitempty: true
+      grade:
+        type: string
+        x-nullable: true
+      grade_comment:
+        type: string
+        x-nullable: true
+      grade_points:
+        format: float
+        type: number
+        x-omitempty: true
+      grader_id:
+        type: string
+        x-nullable: true
+      id:
+        type: string
+      last_modified:
+        format: datetime
+        type: string
+        x-nullable: true
+      override_due_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      state:
+        $ref: '#/definitions/SubmissionState'
+      user_id:
+        type: string
+    type: object
+  SubmissionFlag:
+    enum:
+    - excused
+    - late
+    - missing
+    type: string
+  SubmissionRequest:
+    properties:
+      attachments:
+        items:
+          $ref: '#/definitions/AttachmentRequest'
+        type: array
+        x-omitempty: true
+      extra_attempts:
+        type: integer
+        x-omitempty: true
+      flags:
+        items:
+          $ref: '#/definitions/SubmissionFlag'
+        type: array
+        x-omitempty: true
+      grade:
+        type: string
+        x-nullable: true
+      grade_comment:
+        type: string
+        x-nullable: true
+      grade_points:
+        format: float
+        type: number
+        x-omitempty: true
+      grader_id:
+        type: string
+        x-nullable: true
+      override_due_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      state:
+        $ref: '#/definitions/SubmissionState'
+        x-nullable: true
+    type: object
+  SubmissionResponse:
+    properties:
+      data:
+        $ref: '#/definitions/Submission'
+    type: object
+  SubmissionState:
+    enum:
+    - created
+    - submitted
+    - returned
+    - reclaimed
+    type: string
+  SubmissionType:
+    enum:
+    - link
+    - file
+    - text
+    - discussion
+    type: string
+  SubmissionsLink:
+    properties:
+      rel:
+        enum:
+        - next
+        type: string
+      uri:
+        type: string
+    type: object
+  SubmissionsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/Submission'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/SubmissionsLink'
+        type: array
+        x-omitempty: true
+    type: object
   Teacher:
     properties:
       created:
@@ -1184,6 +1541,11 @@ definitions:
         items:
           $ref: '#/definitions/Link'
         type: array
+    type: object
+  Unauthorized:
+    properties:
+      message:
+        type: string
     type: object
   User:
     properties:
@@ -2129,6 +2491,215 @@ paths:
           $ref: '#/responses/NotFound'
       tags:
       - Data
+  /sections/{section_id}/assignments:
+    post:
+      description: Creates a new assignment in the specified section
+      operationId: createAssignmentForSection
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: body
+        name: assignmentRequestBody
+        required: true
+        schema:
+          $ref: '#/definitions/AssignmentRequest'
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/AssignmentResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+      tags:
+      - LMS Connect
+  /sections/{section_id}/assignments/{assignment_id}:
+    delete:
+      description: Deletes an existing assignment in the specified section
+      operationId: deleteAssignmentForSection
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: path
+        name: assignment_id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK Response
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+      tags:
+      - LMS Connect
+    get:
+      description: Returns a specific assignment for a section
+      operationId: getAssignmentForSection
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: path
+        name: assignment_id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/AssignmentResponse'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+      tags:
+      - LMS Connect
+    patch:
+      description: Updates an existing assignment in the specified section
+      operationId: updateAssignmentForSection
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: path
+        name: assignment_id
+        required: true
+        type: string
+      - in: body
+        name: assignmentRequestBody
+        required: true
+        schema:
+          $ref: '#/definitions/AssignmentRequest'
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/AssignmentResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+        "500":
+          $ref: '#/responses/InternalError'
+      tags:
+      - LMS Connect
+  /sections/{section_id}/assignments/{assignment_id}/submissions:
+    get:
+      description: Returns the submissions for an assignment.
+      operationId: getSubmissionsForAssignment
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: path
+        name: assignment_id
+        required: true
+        type: string
+      - in: query
+        name: cursor
+        type: string
+      - in: query
+        maximum: 100
+        minimum: 1
+        name: limit
+        type: integer
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SubmissionsResponse'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+      tags:
+      - LMS Connect
+  /sections/{section_id}/assignments/{assignment_id}/submissions/{user_id}:
+    get:
+      description: Returns a specific user's submission for an assignment.
+      operationId: getSubmissionForAssignment
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: path
+        name: assignment_id
+        required: true
+        type: string
+      - format: mongo-id
+        in: path
+        name: user_id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SubmissionResponse'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+      tags:
+      - LMS Connect
+    patch:
+      description: Updates an existing submission in the specified assignment for a user.
+      operationId: updateSubmissionForAssignment
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: path
+        name: assignment_id
+        required: true
+        type: string
+      - format: mongo-id
+        in: path
+        name: user_id
+        required: true
+        type: string
+      - in: body
+        name: submissionRequestBody
+        required: true
+        schema:
+          $ref: '#/definitions/SubmissionRequest'
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SubmissionResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+        "500":
+          $ref: '#/responses/InternalError'
+      tags:
+      - LMS Connect
   /terms:
     get:
       description: Returns a list of terms
@@ -2505,6 +3076,10 @@ responses:
     description: Entity Not Found
     schema:
       $ref: '#/definitions/NotFound'
+  Unauthorized:
+    description: Not authorized
+    schema:
+      $ref: '#/definitions/Unauthorized'
 schemes:
 - https
 security:

--- a/v3.1-events.yml
+++ b/v3.1-events.yml
@@ -138,6 +138,16 @@ definitions:
         format: date
         type: string
         x-validation: true
+      lms_state:
+        enum:
+        - matching_in_progress
+        - error
+        - disconnected
+        - ""
+        - success
+        type: string
+        x-nullable: true
+        x-validation: true
       login_methods:
         items:
           type: string

--- a/v3.1-lms.yml
+++ b/v3.1-lms.yml
@@ -397,8 +397,6 @@ paths:
           $ref: '#/responses/BadRequest'
         "401":
           $ref: '#/responses/Unauthorized'
-        "404":
-          $ref: '#/responses/NotFound'
       tags:
       - Assignments
   /sections/{section_id}/assignments/{assignment_id}:

--- a/v3.1-lms.yml
+++ b/v3.1-lms.yml
@@ -1,0 +1,622 @@
+basePath: /v3.1
+definitions:
+  AssigneeMode:
+    enum:
+    - all
+    - individuals
+    type: string
+  Assignment:
+    properties:
+      assignee_ids:
+        items:
+          type: string
+        type: array
+        x-omitempty: true
+      assignee_mode:
+        $ref: '#/definitions/AssigneeMode'
+        x-nullable: true
+      attachments:
+        items:
+          $ref: '#/definitions/Attachment'
+        type: array
+        x-omitempty: true
+      category_id:
+        type: string
+        x-nullable: true
+      created:
+        format: datetime
+        type: string
+        x-nullable: true
+      description:
+        type: string
+      description_plaintext:
+        type: string
+        x-nullable: true
+      display_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      due_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      end_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      grading_scale:
+        items:
+          $ref: '#/definitions/GradingScale'
+        type: array
+        x-omitempty: true
+      grading_type:
+        $ref: '#/definitions/GradingType'
+      id:
+        type: string
+      last_modified:
+        format: datetime
+        type: string
+        x-nullable: true
+      max_attempts:
+        type: integer
+        x-omitempty: true
+      points_possible:
+        format: float
+        type: number
+        x-nullable: true
+      start_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      state:
+        $ref: '#/definitions/AssignmentState'
+      submission_types:
+        items:
+          $ref: '#/definitions/SubmissionType'
+        type: array
+        x-omitempty: true
+      term_id:
+        type: string
+        x-nullable: true
+      title:
+        type: string
+    type: object
+  AssignmentRequest:
+    properties:
+      assignee_ids:
+        items:
+          type: string
+        type: array
+        x-omitempty: true
+      assignee_mode:
+        $ref: '#/definitions/AssigneeMode'
+        x-nullable: true
+      attachments:
+        items:
+          $ref: '#/definitions/AttachmentRequest'
+        type: array
+        x-omitempty: true
+      description:
+        type: string
+        x-nullable: true
+      description_plaintext:
+        type: string
+        x-nullable: true
+      display_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      due_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      end_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      grading_type:
+        $ref: '#/definitions/GradingType'
+        x-nullable: true
+      max_attempts:
+        type: integer
+        x-omitempty: true
+      points_possible:
+        format: float
+        type: number
+        x-nullable: true
+      start_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      submission_types:
+        items:
+          $ref: '#/definitions/SubmissionType'
+        type: array
+        x-omitempty: true
+      term_id:
+        type: string
+        x-nullable: true
+      title:
+        type: string
+        x-nullable: true
+    type: object
+  AssignmentResponse:
+    properties:
+      data:
+        $ref: '#/definitions/Assignment'
+    type: object
+  AssignmentState:
+    enum:
+    - draft
+    - scheduled
+    - open
+    - locked
+    type: string
+  Attachment:
+    properties:
+      description:
+        type: string
+        x-nullable: true
+      file_external_id:
+        type: string
+        x-nullable: true
+      size:
+        format: float
+        type: number
+        x-omitempty: true
+      thumbnail_url:
+        type: string
+        x-nullable: true
+      title:
+        type: string
+        x-nullable: true
+      type:
+        type: string
+      url:
+        type: string
+        x-nullable: true
+    type: object
+  AttachmentRequest:
+    properties:
+      description:
+        type: string
+        x-nullable: true
+      title:
+        type: string
+        x-nullable: true
+      type:
+        enum:
+        - file
+        type: string
+      url:
+        type: string
+        x-nullable: true
+    type: object
+  BadRequest:
+    properties:
+      message:
+        type: string
+    type: object
+  GradingScale:
+    properties:
+      entries:
+        items:
+          $ref: '#/definitions/GradingScaleEntry'
+        type: array
+        x-nullable: true
+      name:
+        type: string
+    type: object
+  GradingScaleEntry:
+    properties:
+      name:
+        type: string
+      value:
+        type: string
+    type: object
+  GradingType:
+    enum:
+    - points
+    - percent
+    - pass_fail
+    - letter_grade
+    type: string
+  InternalError:
+    properties:
+      message:
+        type: string
+    type: object
+  NotFound:
+    properties:
+      message:
+        type: string
+    type: object
+  Submission:
+    properties:
+      assignment_id:
+        type: string
+      attachments:
+        items:
+          $ref: '#/definitions/Attachment'
+        type: array
+        x-omitempty: true
+      created:
+        format: datetime
+        type: string
+        x-nullable: true
+      extra_attempts:
+        type: integer
+        x-omitempty: true
+      flags:
+        items:
+          $ref: '#/definitions/SubmissionFlag'
+        type: array
+        x-omitempty: true
+      grade:
+        type: string
+        x-nullable: true
+      grade_comment:
+        type: string
+        x-nullable: true
+      grade_points:
+        format: float
+        type: number
+        x-omitempty: true
+      grader_id:
+        type: string
+        x-nullable: true
+      id:
+        type: string
+      last_modified:
+        format: datetime
+        type: string
+        x-nullable: true
+      override_due_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      state:
+        $ref: '#/definitions/SubmissionState'
+      user_id:
+        type: string
+    type: object
+  SubmissionFlag:
+    enum:
+    - excused
+    - late
+    - missing
+    type: string
+  SubmissionRequest:
+    properties:
+      attachments:
+        items:
+          $ref: '#/definitions/AttachmentRequest'
+        type: array
+        x-omitempty: true
+      extra_attempts:
+        type: integer
+        x-omitempty: true
+      flags:
+        items:
+          $ref: '#/definitions/SubmissionFlag'
+        type: array
+        x-omitempty: true
+      grade:
+        type: string
+        x-nullable: true
+      grade_comment:
+        type: string
+        x-nullable: true
+      grade_points:
+        format: float
+        type: number
+        x-omitempty: true
+      grader_id:
+        type: string
+        x-nullable: true
+      override_due_date:
+        format: datetime
+        type: string
+        x-nullable: true
+      state:
+        $ref: '#/definitions/SubmissionState'
+        x-nullable: true
+    type: object
+  SubmissionResponse:
+    properties:
+      data:
+        $ref: '#/definitions/Submission'
+    type: object
+  SubmissionState:
+    enum:
+    - created
+    - submitted
+    - returned
+    - reclaimed
+    type: string
+  SubmissionType:
+    enum:
+    - link
+    - file
+    - text
+    - discussion
+    type: string
+  SubmissionsLink:
+    properties:
+      rel:
+        enum:
+        - next
+        type: string
+      uri:
+        type: string
+    type: object
+  SubmissionsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/Submission'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/SubmissionsLink'
+        type: array
+        x-omitempty: true
+    type: object
+  Unauthorized:
+    properties:
+      message:
+        type: string
+    type: object
+host: api.clever.com
+info:
+  description: The Clever LMS Connect API
+  title: LMS Connect API
+  version: 3.1.0
+paths:
+  /sections/{section_id}/assignments:
+    post:
+      description: Creates a new assignment in the specified section
+      operationId: createAssignmentForSection
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: body
+        name: assignmentRequestBody
+        required: true
+        schema:
+          $ref: '#/definitions/AssignmentRequest'
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/AssignmentResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+      tags:
+      - Assignments
+  /sections/{section_id}/assignments/{assignment_id}:
+    delete:
+      description: Deletes an existing assignment in the specified section
+      operationId: deleteAssignmentForSection
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: path
+        name: assignment_id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK Response
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+      tags:
+      - Assignments
+    get:
+      description: Returns a specific assignment for a section
+      operationId: getAssignmentForSection
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: path
+        name: assignment_id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/AssignmentResponse'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+      tags:
+      - Assignments
+    patch:
+      description: Updates an existing assignment in the specified section
+      operationId: updateAssignmentForSection
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: path
+        name: assignment_id
+        required: true
+        type: string
+      - in: body
+        name: assignmentRequestBody
+        required: true
+        schema:
+          $ref: '#/definitions/AssignmentRequest'
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/AssignmentResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+        "500":
+          $ref: '#/responses/InternalError'
+      tags:
+      - Assignments
+  /sections/{section_id}/assignments/{assignment_id}/submissions:
+    get:
+      description: Returns the submissions for an assignment.
+      operationId: getSubmissionsForAssignment
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: path
+        name: assignment_id
+        required: true
+        type: string
+      - in: query
+        name: cursor
+        type: string
+      - in: query
+        maximum: 100
+        minimum: 1
+        name: limit
+        type: integer
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SubmissionsResponse'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+      tags:
+      - Assignments
+  /sections/{section_id}/assignments/{assignment_id}/submissions/{user_id}:
+    get:
+      description: Returns a specific user's submission for an assignment.
+      operationId: getSubmissionForAssignment
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: path
+        name: assignment_id
+        required: true
+        type: string
+      - format: mongo-id
+        in: path
+        name: user_id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SubmissionResponse'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+      tags:
+      - Submissions
+    patch:
+      description: Updates an existing submission in the specified assignment for a user.
+      operationId: updateSubmissionForAssignment
+      parameters:
+      - format: mongo-id
+        in: path
+        name: section_id
+        required: true
+        type: string
+      - in: path
+        name: assignment_id
+        required: true
+        type: string
+      - format: mongo-id
+        in: path
+        name: user_id
+        required: true
+        type: string
+      - in: body
+        name: submissionRequestBody
+        required: true
+        schema:
+          $ref: '#/definitions/SubmissionRequest'
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/SubmissionResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+        "500":
+          $ref: '#/responses/InternalError'
+      tags:
+      - Submissions
+produces:
+- application/json
+responses:
+  BadRequest:
+    description: Bad Request
+    schema:
+      $ref: '#/definitions/BadRequest'
+  InternalError:
+    description: Internal Error
+    schema:
+      $ref: '#/definitions/InternalError'
+  NotFound:
+    description: Entity Not Found
+    schema:
+      $ref: '#/definitions/NotFound'
+  Unauthorized:
+    description: Not authorized
+    schema:
+      $ref: '#/definitions/Unauthorized'
+schemes:
+- https
+security:
+- oauth: []
+securityDefinitions:
+  oauth:
+    authorizationUrl: https://clever.com/oauth/authorize
+    flow: accessCode
+    tokenUrl: https://clever.com/oauth/tokens
+    type: oauth2
+swagger: "2.0"
+x-samples-languages:
+- curl
+- node
+- ruby
+- python
+- php
+- java
+- go

--- a/v3.1.yml
+++ b/v3.1.yml
@@ -133,6 +133,16 @@ definitions:
         format: date
         type: string
         x-validation: true
+      lms_state:
+        enum:
+        - matching_in_progress
+        - error
+        - disconnected
+        - ""
+        - success
+        type: string
+        x-nullable: true
+        x-validation: true
       login_methods:
         items:
           type: string

--- a/v3/generate.go
+++ b/v3/generate.go
@@ -201,9 +201,8 @@ func modifyDefinitions(version string, isClient bool, name string, def map[inter
 	case "District":
 		if version == "v3.0" {
 			delete(properties, "lms_state")
-		}
-		if !isClient {
-			if version == "v3.0" {
+
+			if !isClient {
 				delete(properties, "lms_state")
 			}
 		}


### PR DESCRIPTION
## Link to JIRA
[SHAPI-996](https://clever.atlassian.net/browse/SHAPI-996)

Review by commit.

Adds new LMS Connect endpoints (Create/Get/Update/Delete Assignment, Get/List/Update Submissions) to the v3.1 schema, as well as an update to the v3.1 `/districts` endpoint adding the `lms_state` field. The LMS Connect endpoints are added to a new `v3.1-lms.yml` file. (To do: updates pending PE feedback)

- Modified files: `full-v3.yml` and `v3/generate.go`
- Files auto-generated/auto-updated: `v3.1.yml`, `v3.1-client.yml`, `v3.1-events.yml`, `v3.1-lms.yml`

## Testing
Ran `make generate VERSION=3` to generate the API schema files for `v3.1` and checked that only v3.1 files were changed.

[SHAPI-996]: https://clever.atlassian.net/browse/SHAPI-996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ