### PR TITLE
Update i18n-go package version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Clever/swagger-api
 go 1.21
 
 require (
-	github.com/Clever/i18n-go/v2 v2.0.1
+	github.com/Clever/i18n-go/v2 v2.1.0
 	github.com/Clever/yaml v0.0.0-20170104005607-8f7677dc217d
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Clever/i18n-go/v2 v2.0.1 h1:ZXZgLcLK2YLQ/nRQ6EsOGkqpZsj0yWyjLJaQO1VhXW4=
 github.com/Clever/i18n-go/v2 v2.0.1/go.mod h1:S+fBBGo/9Qu+OpF+QGfU0WNq8au8RCi9a4sXwmOmOwY=
+github.com/Clever/i18n-go/v2 v2.1.0 h1:jnNEeJ05sinJhs8V3VyTZ3/LzgXLITeXuByzqSRY1mk=
+github.com/Clever/i18n-go/v2 v2.1.0/go.mod h1:Pu3OSxZTqyS16IZYOzZxXVnlsf9b8l9g/Pd2FOgjj70=
 github.com/Clever/yaml v0.0.0-20170104005607-8f7677dc217d h1:zONh7OShm/893Z8SSUFcEjt18U25RfyhYXqji/YNlMA=
 github.com/Clever/yaml v0.0.0-20170104005607-8f7677dc217d/go.mod h1:xTFjuOEBi/S0ANVudaU5HFMC0XXuBZOgYFKotUKnDbo=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=


### PR DESCRIPTION
## Link to JIRA:

https://clever.atlassian.net/browse/SHAPI-1099

## Overview:

This PR pulls in the latest i18n package version, which has an updated list of supported home languages. We want to support all of the [languages that TalkingPoints supports](https://talkingpts.org/pdf/TalkingPoints-Supported%20languages.pdf?_t=1667488473) in our APIs.

## Testing

NA, will package update in other API repos

## Rollout

100%
