### PR TITLE
Add lms_type to v3.1 /districts endpoint

### DIFF
--- a/full-v3.yml
+++ b/full-v3.yml
@@ -1590,6 +1590,15 @@ definitions:
         - "disconnected"
         - ""
         - "success"
+      lms_type:
+        type: string
+        x-nullable: true
+        x-validation: true
+        enum:
+        - "canvas"
+        - "schoology"
+        - "google_classroom"
+        - ""
       name:
         type: string
       mdr_number:

--- a/v3.1-client.yml
+++ b/v3.1-client.yml
@@ -340,6 +340,15 @@ definitions:
         type: string
         x-nullable: true
         x-validation: true
+      lms_type:
+        enum:
+        - canvas
+        - schoology
+        - google_classroom
+        - ""
+        type: string
+        x-nullable: true
+        x-validation: true
       login_methods:
         items:
           type: string

--- a/v3.1-events.yml
+++ b/v3.1-events.yml
@@ -148,6 +148,15 @@ definitions:
         type: string
         x-nullable: true
         x-validation: true
+      lms_type:
+        enum:
+        - canvas
+        - schoology
+        - google_classroom
+        - ""
+        type: string
+        x-nullable: true
+        x-validation: true
       login_methods:
         items:
           type: string

--- a/v3.1.yml
+++ b/v3.1.yml
@@ -143,6 +143,15 @@ definitions:
         type: string
         x-nullable: true
         x-validation: true
+      lms_type:
+        enum:
+        - canvas
+        - schoology
+        - google_classroom
+        - ""
+        type: string
+        x-nullable: true
+        x-validation: true
       login_methods:
         items:
           type: string

--- a/v3/generate.go
+++ b/v3/generate.go
@@ -201,10 +201,7 @@ func modifyDefinitions(version string, isClient bool, name string, def map[inter
 	case "District":
 		if version == "v3.0" {
 			delete(properties, "lms_state")
-
-			if !isClient {
-				delete(properties, "lms_state")
-			}
+			delete(properties, "lms_type")
 		}
 	default:
 	}


### PR DESCRIPTION
https://clever.atlassian.net/browse/SHAPI-1119

Adds the `lms_type` field to the v3.1 `/districts` endpoint.

- Modified files: `full-v3.yml` and `v3/generate.go`
- Files auto-generated/auto-updated: `v3.1.yml`, `v3.1-client.yml`, `v3.1-events.yml``

## Testing
Ran `make generate VERSION=3` to generate the API schema files for `v3.1` and checked that only v3.1 files were changed.