### PR TITLE
v3.1 schema update for Attendance endpoints

### DIFF
--- a/full-v3.yml
+++ b/full-v3.yml
@@ -1285,6 +1285,105 @@ paths:
         '500':
           $ref: "#/responses/InternalError"
 
+  # Attendance API endpoints
+  /attendance/schools/{school_id}:
+    get:
+      summary: Returns a list of attendance records for a school
+      operationId: listAttendanceForSchool
+      parameters:
+        - name: school_id
+          in: path
+          type: string
+          required: true
+        - name: date_range_start
+          in: query
+          type: string
+          format: date
+        - name: date_range_end
+          in: query
+          type: string
+          format: date
+        - name: status
+          in: query
+          type: string
+          enum:
+            - present
+            - absent
+            - tardy
+        - name: limit
+          in: query
+          type: integer
+          minimum: 1
+          maximum: 1000
+        - name: starting_after
+          in: query
+          type: string
+        - name: ending_before
+          in: query
+          type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: "#/definitions/AttendanceResponse"
+        '400':
+          $ref: "#/responses/BadRequest"
+        '401':
+          $ref: "#/responses/Unauthorized"
+        '404':
+          $ref: "#/responses/NotFound"
+        '500':
+          $ref: "#/responses/InternalError"
+
+  /attendance/sections/{section_id}:
+    get:
+      summary: Returns a list of attendance records for a section
+      operationId: listAttendanceForSection
+      parameters:
+        - name: section_id
+          in: path
+          type: string
+          required: true
+        - name: date_range_start
+          in: query
+          type: string
+          format: date
+        - name: date_range_end
+          in: query
+          type: string
+          format: date
+        - name: status
+          in: query
+          type: string
+          enum:
+            - present
+            - absent
+            - tardy
+        - name: limit
+          in: query
+          type: integer
+          minimum: 1
+          maximum: 1000
+        - name: starting_after
+          in: query
+          type: string
+        - name: ending_before
+          in: query
+          type: string
+      responses:
+        '200':
+          description: OK Response
+          schema:
+            $ref: "#/definitions/AttendanceResponse"
+        '400':
+          $ref: "#/responses/BadRequest"
+        '401':
+          $ref: "#/responses/Unauthorized"
+        '404':
+          $ref: "#/responses/NotFound"
+        '500':
+          $ref: "#/responses/InternalError"
+
   /events:
     get:
       tags: ["Events"]
@@ -1622,6 +1721,11 @@ definitions:
         - ""
         - "success"
       last_sync:
+        type: string
+        x-validation: true
+        x-nullable: true
+        format: datetime
+      last_attendance_sync:
         type: string
         x-validation: true
         x-nullable: true
@@ -2440,6 +2544,7 @@ definitions:
       object:
         $ref: "#/definitions/User"
 
+  # LMS Connect definitions
   Assignment:
     type: object
     properties:
@@ -2806,6 +2911,72 @@ definitions:
         type: string
       uri:
         type: string
+
+  # Attendance API definitions
+  Attendance:
+    type: object
+    properties:
+      district_id:
+        type: string
+        format: mongo-id
+      school_id:
+        type: string
+        format: mongo-id
+      student_id:
+        type: string
+        format: mongo-id
+      sis_id:
+        type: string
+      section_id:
+        type: string
+        format: mongo-id
+      created:
+        type: string
+        format: datetime
+      last_modified:
+        type: string
+        format: datetime
+      attendance_date:
+        type: string
+        format: date
+      attendance_status:
+        $ref: "#/definitions/AttendanceStatus"
+      attendance_type:
+        $ref: "#/definitions/AttendanceType"
+      duration:
+        type: number
+        format: integer
+      excuse_code:
+        type: string
+
+  AttendanceStatus:
+    type: string
+    enum:
+      - present
+      - absent
+      - tardy
+
+  AttendanceType:
+    type: string
+    enum:
+      - daily
+      - section
+
+  AttendanceResponse:
+    type: object
+    properties:
+      data:
+        type: array
+        items:
+          $ref: "#/definitions/Attendance"
+      total:
+        x-omitempty: false
+        type: integer
+      links:
+        x-omitempty: true
+        type: array
+        items:
+          $ref: "#/definitions/Link"
 
   EventsResponse:
     type: object

--- a/v3.1-attendance.yml
+++ b/v3.1-attendance.yml
@@ -1,0 +1,218 @@
+basePath: /v3.1
+definitions:
+  Attendance:
+    properties:
+      attendance_date:
+        format: date
+        type: string
+      attendance_status:
+        $ref: '#/definitions/AttendanceStatus'
+      attendance_type:
+        $ref: '#/definitions/AttendanceType'
+      created:
+        format: datetime
+        type: string
+      district_id:
+        format: mongo-id
+        type: string
+      duration:
+        format: integer
+        type: number
+      excuse_code:
+        type: string
+      last_modified:
+        format: datetime
+        type: string
+      school_id:
+        format: mongo-id
+        type: string
+      section_id:
+        format: mongo-id
+        type: string
+      sis_id:
+        type: string
+      student_id:
+        format: mongo-id
+        type: string
+    type: object
+  AttendanceResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/Attendance'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
+        x-omitempty: true
+      total:
+        type: integer
+        x-omitempty: false
+    type: object
+  AttendanceStatus:
+    enum:
+    - present
+    - absent
+    - tardy
+    type: string
+  AttendanceType:
+    enum:
+    - daily
+    - section
+    type: string
+  BadRequest:
+    properties:
+      message:
+        type: string
+    type: object
+  InternalError:
+    properties:
+      message:
+        type: string
+    type: object
+  NotFound:
+    properties:
+      message:
+        type: string
+    type: object
+host: api.clever.com
+info:
+  description: The Clever Attendance API
+  title: Attendance API
+  version: 3.1.0
+paths:
+  /attendance/schools/{school_id}:
+    get:
+      operationId: listAttendanceForSchool
+      parameters:
+      - in: path
+        name: school_id
+        required: true
+        type: string
+      - format: date
+        in: query
+        name: date_range_start
+        type: string
+      - format: date
+        in: query
+        name: date_range_end
+        type: string
+      - enum:
+        - present
+        - absent
+        - tardy
+        in: query
+        name: status
+        type: string
+      - in: query
+        maximum: 1000
+        minimum: 1
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/AttendanceResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Returns a list of attendance records for a school
+  /attendance/sections/{section_id}:
+    get:
+      operationId: listAttendanceForSection
+      parameters:
+      - in: path
+        name: section_id
+        required: true
+        type: string
+      - format: date
+        in: query
+        name: date_range_start
+        type: string
+      - format: date
+        in: query
+        name: date_range_end
+        type: string
+      - enum:
+        - present
+        - absent
+        - tardy
+        in: query
+        name: status
+        type: string
+      - in: query
+        maximum: 1000
+        minimum: 1
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/AttendanceResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Returns a list of attendance records for a section
+produces:
+- application/json
+responses:
+  BadRequest:
+    description: Bad Request
+    schema:
+      $ref: '#/definitions/BadRequest'
+  InternalError:
+    description: Internal Error
+    schema:
+      $ref: '#/definitions/InternalError'
+  NotFound:
+    description: Entity Not Found
+    schema:
+      $ref: '#/definitions/NotFound'
+  Unauthorized:
+    description: Not authorized
+    schema:
+      $ref: '#/definitions/Unauthorized'
+schemes:
+- https
+security:
+- oauth: []
+securityDefinitions:
+  oauth:
+    authorizationUrl: https://clever.com/oauth/authorize
+    flow: accessCode
+    tokenUrl: https://clever.com/oauth/tokens
+    type: oauth2
+swagger: "2.0"
+x-samples-languages:
+- curl
+- node
+- ruby
+- python
+- php
+- java
+- go

--- a/v3.1-client.yml
+++ b/v3.1-client.yml
@@ -192,6 +192,67 @@ definitions:
         type: string
         x-nullable: true
     type: object
+  Attendance:
+    properties:
+      attendance_date:
+        format: date
+        type: string
+      attendance_status:
+        $ref: '#/definitions/AttendanceStatus'
+      attendance_type:
+        $ref: '#/definitions/AttendanceType'
+      created:
+        format: datetime
+        type: string
+      district_id:
+        format: mongo-id
+        type: string
+      duration:
+        format: integer
+        type: number
+      excuse_code:
+        type: string
+      last_modified:
+        format: datetime
+        type: string
+      school_id:
+        format: mongo-id
+        type: string
+      section_id:
+        format: mongo-id
+        type: string
+      sis_id:
+        type: string
+      student_id:
+        format: mongo-id
+        type: string
+    type: object
+  AttendanceResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/Attendance'
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/Link'
+        type: array
+        x-omitempty: true
+      total:
+        type: integer
+        x-omitempty: false
+    type: object
+  AttendanceStatus:
+    enum:
+    - present
+    - absent
+    - tardy
+    type: string
+  AttendanceType:
+    enum:
+    - daily
+    - section
+    type: string
   BadRequest:
     properties:
       message:
@@ -320,6 +381,11 @@ definitions:
         type: string
       id:
         type: string
+        x-validation: true
+      last_attendance_sync:
+        format: datetime
+        type: string
+        x-nullable: true
         x-validation: true
       last_sync:
         format: datetime
@@ -1858,6 +1924,106 @@ info:
   title: Clever API
   version: 3.1.0
 paths:
+  /attendance/schools/{school_id}:
+    get:
+      operationId: listAttendanceForSchool
+      parameters:
+      - in: path
+        name: school_id
+        required: true
+        type: string
+      - format: date
+        in: query
+        name: date_range_start
+        type: string
+      - format: date
+        in: query
+        name: date_range_end
+        type: string
+      - enum:
+        - present
+        - absent
+        - tardy
+        in: query
+        name: status
+        type: string
+      - in: query
+        maximum: 1000
+        minimum: 1
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/AttendanceResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Returns a list of attendance records for a school
+      tags:
+      - Attendance
+  /attendance/sections/{section_id}:
+    get:
+      operationId: listAttendanceForSection
+      parameters:
+      - in: path
+        name: section_id
+        required: true
+        type: string
+      - format: date
+        in: query
+        name: date_range_start
+        type: string
+      - format: date
+        in: query
+        name: date_range_end
+        type: string
+      - enum:
+        - present
+        - absent
+        - tardy
+        in: query
+        name: status
+        type: string
+      - in: query
+        maximum: 1000
+        minimum: 1
+        name: limit
+        type: integer
+      - in: query
+        name: starting_after
+        type: string
+      - in: query
+        name: ending_before
+        type: string
+      responses:
+        "200":
+          description: OK Response
+          schema:
+            $ref: '#/definitions/AttendanceResponse'
+        "400":
+          $ref: '#/responses/BadRequest'
+        "401":
+          $ref: '#/responses/Unauthorized'
+        "404":
+          $ref: '#/responses/NotFound'
+        "500":
+          $ref: '#/responses/InternalError'
+      summary: Returns a list of attendance records for a section
+      tags:
+      - Attendance
   /courses:
     get:
       description: Returns a list of courses

--- a/v3.1-events.yml
+++ b/v3.1-events.yml
@@ -129,6 +129,11 @@ definitions:
       id:
         type: string
         x-validation: true
+      last_attendance_sync:
+        format: datetime
+        type: string
+        x-nullable: true
+        x-validation: true
       last_sync:
         format: datetime
         type: string

--- a/v3.1.yml
+++ b/v3.1.yml
@@ -124,6 +124,11 @@ definitions:
       id:
         type: string
         x-validation: true
+      last_attendance_sync:
+        format: datetime
+        type: string
+        x-nullable: true
+        x-validation: true
       last_sync:
         format: datetime
         type: string

--- a/v3/generate.go
+++ b/v3/generate.go
@@ -41,6 +41,13 @@ var lmsConnectModels = []string{
 	"SubmissionsLink",
 }
 
+var attendanceModels = []string{
+	"Attendance",
+	"AttendanceResponse",
+	"AttendanceStatus",
+	"AttendanceType",
+}
+
 // Generate generates API source ymls for the major/minor versions.
 func Generate() {
 	for _, minorVersion := range minorVersions {
@@ -63,7 +70,7 @@ func Generate() {
 
 		if versionStr == "v3.0" {
 			deleteV31Definitions(swaggerCopy)
-			deleteLMSConnectObjects(swaggerCopy)
+			deleteV31PlusSeparateAPIObjects(swaggerCopy)
 		}
 
 		clientBytes, err := generateClientYml(swaggerCopy, versionStr)
@@ -98,12 +105,24 @@ func Generate() {
 			if err := ioutil.WriteFile(versionStr+"-lms.yml", versionLMSConnect, 0644); err != nil {
 				log.Fatalf("Error writing LMS Connect %s API: %s", versionStr, err)
 			}
+
+			versionAttendance, err := generateAttendanceAPIYml(swaggerCopy, versionStr)
+			if err != nil {
+				log.Fatalf("Error generating Attendance %s API: %s", versionStr, err)
+			}
+			if err := ioutil.WriteFile(versionStr+"-attendance.yml", versionAttendance, 0644); err != nil {
+				log.Fatalf("Error writing Attendance %s API: %s", versionStr, err)
+			}
 		}
 	}
 }
 
 func isLMSConnectEndpoint(path interface{}) bool {
 	return strings.Contains(path.(string), "/assignments") || strings.Contains(path.(string), "/submissions")
+}
+
+func isAttendanceEndpoint(path interface{}) bool {
+	return strings.Contains(path.(string), "/attendance")
 }
 
 // duplicateMap creates a deep copy of the provided map
@@ -125,8 +144,9 @@ func duplicateMap(m map[interface{}]interface{}) map[interface{}]interface{} {
 	return cp
 }
 
-// deleteLMSConnectResponses deletes responses and definitions not used in v3.0 of our APIs
-func deleteLMSConnectObjects(i map[interface{}]interface{}) error {
+// deleteV31PlusSeparateAPIObjects deletes responses and definitions specific to
+// LMS Connect and Attendance endpoints (only in v3.1+ and separate from Data and Events APIs)
+func deleteV31PlusSeparateAPIObjects(i map[interface{}]interface{}) error {
 	responses, ok := i["responses"].(map[interface{}]interface{})
 	if ok {
 		delete(responses, "Unauthorized")
@@ -137,6 +157,9 @@ func deleteLMSConnectObjects(i map[interface{}]interface{}) error {
 	definitions, ok := i["definitions"].(map[interface{}]interface{})
 	if ok {
 		for _, modelName := range lmsConnectModels {
+			delete(definitions, modelName)
+		}
+		for _, modelName := range attendanceModels {
 			delete(definitions, modelName)
 		}
 	} else {
@@ -203,6 +226,7 @@ func modifyDefinitions(version string, isClient bool, name string, def map[inter
 		if version == "v3.0" {
 			delete(properties, "lms_state")
 			delete(properties, "lms_type")
+			delete(properties, "last_attendance_sync")
 		}
 	case "Section":
 		if version == "v3.0" {
@@ -217,7 +241,7 @@ func modifyDefinitions(version string, isClient bool, name string, def map[inter
 }
 
 // generateDataAPIYml generates the data API from the base yml for a specific version. It does
-// this by removing things from the yml, for example the /events and LMS Connect endpoints.
+// this by removing things from the yml, for example the /events, LMS Connect, and Attendance endpoints.
 func generateDataAPIYml(i map[interface{}]interface{}, version string) ([]byte, error) {
 	m := sharedlib.DeepCopyMap(i)
 
@@ -228,7 +252,7 @@ func generateDataAPIYml(i map[interface{}]interface{}, version string) ([]byte, 
 	paths := m["paths"].(map[interface{}]interface{})
 	for path, methodOp := range paths {
 		if strings.Contains(path.(string), "/events") && path.(string) != "/districts/{id}/status" ||
-			isLMSConnectEndpoint(path) {
+			isLMSConnectEndpoint(path) || isAttendanceEndpoint(path) {
 			delete(paths, path)
 			continue
 		}
@@ -248,7 +272,7 @@ func generateDataAPIYml(i map[interface{}]interface{}, version string) ([]byte, 
 		}
 	}
 
-	deleteLMSConnectObjects(m)
+	deleteV31PlusSeparateAPIObjects(m)
 	definitions := m["definitions"].(map[interface{}]interface{})
 	for nameInterface, definition := range definitions {
 		name := nameInterface.(string)
@@ -290,7 +314,7 @@ func generateEventsAPIYml(i map[interface{}]interface{}, version string) ([]byte
 		}
 	}
 
-	deleteLMSConnectObjects(m)
+	deleteV31PlusSeparateAPIObjects(m)
 	definitions := m["definitions"].(map[interface{}]interface{})
 	for nameInterface, definition := range definitions {
 		name := nameInterface.(string)
@@ -358,6 +382,64 @@ func generateLMSConnectAPIYml(i map[interface{}]interface{}, version string) ([]
 	return yaml.Marshal(m)
 }
 
+// generateAttendanceAPIYml generates the Attendance API from the base yml for a specific version. It does
+// this by removing things from the yml, for example the non-Attendance endpoints.
+func generateAttendanceAPIYml(i map[interface{}]interface{}, version string) ([]byte, error) {
+	m := sharedlib.DeepCopyMap(i)
+
+	m["basePath"] = "/" + version
+	info := m["info"].(map[interface{}]interface{})
+	info["title"] = "Attendance API"
+	info["description"] = "The Clever Attendance API"
+	info["version"] = strings.Replace(version, "v", "", -1) + ".0"
+
+	paths := m["paths"].(map[interface{}]interface{})
+	for path, methodOp := range paths {
+		if !isAttendanceEndpoint(path) {
+			delete(paths, path)
+			continue
+		}
+
+		for _, o := range methodOp.(map[interface{}]interface{}) {
+			operation := o.(map[interface{}]interface{})
+			params, ok := operation["parameters"].([]interface{})
+			if !ok {
+				continue
+			}
+			paramsForClient := make([]map[interface{}]interface{}, 0)
+			for _, p := range params {
+				param := p.(map[interface{}]interface{})
+				paramsForClient = append(paramsForClient, param)
+			}
+			operation["parameters"] = paramsForClient
+		}
+	}
+
+	definitions := m["definitions"].(map[interface{}]interface{})
+	// Remove Data + Events API models from Attendance file
+	attendanceModelsPlusSharedModels := append(attendanceModels, []string{
+		"BadRequest",
+		"InternalError",
+		"NotFound",
+	}...)
+	for nameInterface, _ := range definitions {
+		name := nameInterface.(string)
+		isAttendanceModel := false
+		for _, attendanceModelName := range attendanceModelsPlusSharedModels {
+			if attendanceModelName == name {
+				isAttendanceModel = true
+				continue
+			}
+		}
+
+		if !isAttendanceModel {
+			delete(definitions, nameInterface)
+		}
+	}
+
+	return yaml.Marshal(m)
+}
+
 // generateClientYml generates the yml for the client libraries. It removes things we don't need
 // implementations to use.
 func generateClientYml(i map[interface{}]interface{}, versionStr string) ([]byte, error) {
@@ -372,7 +454,7 @@ func generateClientYml(i map[interface{}]interface{}, versionStr string) ([]byte
 	paths := m["paths"].(map[interface{}]interface{})
 	for path, methodOp := range paths {
 		// LMS Connect API is v3.1 and above
-		if versionStr == "v3.0" && isLMSConnectEndpoint(path) {
+		if versionStr == "v3.0" && (isLMSConnectEndpoint(path) || isAttendanceEndpoint(path)) {
 			delete(paths, path)
 			continue
 		}
@@ -385,6 +467,8 @@ func generateClientYml(i map[interface{}]interface{}, versionStr string) ([]byte
 				operation["tags"] = []string{"Events"}
 			} else if isLMSConnectEndpoint(path) {
 				operation["tags"] = []string{"LMS Connect"}
+			} else if isAttendanceEndpoint(path) {
+				operation["tags"] = []string{"Attendance"}
 			} else {
 				operation["tags"] = []string{"Data"}
 			}


### PR DESCRIPTION
## Link to JIRA
[SHAPI-1553](https://clever.atlassian.net/browse/SHAPI-1553)

Review by commit.

Adds new Attendance endpoints (GET attendance by school, GET attendance by section) to the v3.1 schema, as well as an update to the v3.1 `/districts` endpoint adding the `last_attendance_sync` field. The Attendance endpoints are added to a new `v3.1-attendance.yml` file. (To do: updates pending PE feedback)

- Modified files: `full-v3.yml` and `v3/generate.go`
- Files auto-generated/auto-updated: `v3.1.yml`, `v3.1-client.yml`, `v3.1-events.yml`, `v3.1-attendance.yml`

## Testing
Ran `make generate VERSION=3` to generate the API schema files for `v3.1` and checked that only v3.1 files were changed.

[SHAPI-1553]: https://clever.atlassian.net/browse/SHAPI-1553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ