### PR TITLE
Remove duration from attendance model

### DIFF
--- a/full-v3.yml
+++ b/full-v3.yml
@@ -2943,9 +2943,6 @@ definitions:
         $ref: "#/definitions/AttendanceStatus"
       attendance_type:
         $ref: "#/definitions/AttendanceType"
-      duration:
-        type: number
-        format: integer
       excuse_code:
         type: string
 

--- a/v3.1-attendance.yml
+++ b/v3.1-attendance.yml
@@ -15,9 +15,6 @@ definitions:
       district_id:
         format: mongo-id
         type: string
-      duration:
-        format: integer
-        type: number
       excuse_code:
         type: string
       last_modified:

--- a/v3.1-client.yml
+++ b/v3.1-client.yml
@@ -207,9 +207,6 @@ definitions:
       district_id:
         format: mongo-id
         type: string
-      duration:
-        format: integer
-        type: number
       excuse_code:
         type: string
       last_modified:


### PR DESCRIPTION
## Link to JIRA
[SHAPI-1630](https://clever.atlassian.net/browse/SHAPI-1630)

Omit the `duration` field from the attendance model.
- Modified files: `full-v3.yml`
- Files auto-generated/auto-updated: `v3.1-client.yml`, `v3.1-attendance.yml`

## Testing
Ran `make generate VERSION=3` to generate the API schema files for `v3.1` and checked that only relevant v3.1 files were changed.

[SHAPI-1630]: https://clever.atlassian.net/browse/SHAPI-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ