### PR TITLE
Change status param name and remove total field

### DIFF
--- a/full-v3.yml
+++ b/full-v3.yml
@@ -2966,9 +2966,6 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/Attendance"
-      total:
-        x-omitempty: false
-        type: integer
       links:
         x-omitempty: true
         type: array

--- a/full-v3.yml
+++ b/full-v3.yml
@@ -1303,7 +1303,7 @@ paths:
           in: query
           type: string
           format: date
-        - name: status
+        - name: attendance_status
           in: query
           type: string
           enum:
@@ -1352,7 +1352,7 @@ paths:
           in: query
           type: string
           format: date
-        - name: status
+        - name: attendance_status
           in: query
           type: string
           enum:

--- a/v3.1-attendance.yml
+++ b/v3.1-attendance.yml
@@ -43,9 +43,6 @@ definitions:
           $ref: '#/definitions/Link'
         type: array
         x-omitempty: true
-      total:
-        type: integer
-        x-omitempty: false
     type: object
   AttendanceStatus:
     enum:

--- a/v3.1-attendance.yml
+++ b/v3.1-attendance.yml
@@ -100,7 +100,7 @@ paths:
         - absent
         - tardy
         in: query
-        name: status
+        name: attendance_status
         type: string
       - in: query
         maximum: 1000
@@ -148,7 +148,7 @@ paths:
         - absent
         - tardy
         in: query
-        name: status
+        name: attendance_status
         type: string
       - in: query
         maximum: 1000

--- a/v3.1-client.yml
+++ b/v3.1-client.yml
@@ -1942,7 +1942,7 @@ paths:
         - absent
         - tardy
         in: query
-        name: status
+        name: attendance_status
         type: string
       - in: query
         maximum: 1000
@@ -1992,7 +1992,7 @@ paths:
         - absent
         - tardy
         in: query
-        name: status
+        name: attendance_status
         type: string
       - in: query
         maximum: 1000

--- a/v3.1-client.yml
+++ b/v3.1-client.yml
@@ -235,9 +235,6 @@ definitions:
           $ref: '#/definitions/Link'
         type: array
         x-omitempty: true
-      total:
-        type: integer
-        x-omitempty: false
     type: object
   AttendanceStatus:
     enum:


### PR DESCRIPTION
## Link to JIRA
[SHAPI-1630](https://clever.atlassian.net/browse/SHAPI-1630)

Changes the `status` param in the attendance endpoints to `attendance_status`. Also removes the `total` field from the response as it was not part of the product requirements.
- Modified files: `full-v3.yml`
- Files auto-generated/auto-updated: `v3.1-client.yml`, `v3.1-attendance.yml`

## Testing
Ran `make generate VERSION=3` to generate the API schema files for `v3.1` and checked that only relevant v3.1 files were changed.

[SHAPI-1630]: https://clever.atlassian.net/browse/SHAPI-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ