### PR TITLE
fix: Backfill LMS state values initial_sync_processing and pending_authorization

### DIFF
--- a/full-v3.yml
+++ b/full-v3.yml
@@ -1684,11 +1684,13 @@ definitions:
         x-nullable: true
         x-validation: true
         enum:
-        - "matching_in_progress"
-        - "error"
-        - "disconnected"
+        - initial_sync_processing
+        - pending_authorization
+        - matching_in_progress
+        - error
+        - disconnected
         - ""
-        - "success"
+        - success
       lms_type:
         type: string
         x-nullable: true

--- a/v3.1-client.yml
+++ b/v3.1-client.yml
@@ -392,6 +392,8 @@ definitions:
         x-validation: true
       lms_state:
         enum:
+        - initial_sync_processing
+        - pending_authorization
         - matching_in_progress
         - error
         - disconnected

--- a/v3.1-events.yml
+++ b/v3.1-events.yml
@@ -145,6 +145,8 @@ definitions:
         x-validation: true
       lms_state:
         enum:
+        - initial_sync_processing
+        - pending_authorization
         - matching_in_progress
         - error
         - disconnected

--- a/v3.1.yml
+++ b/v3.1.yml
@@ -140,6 +140,8 @@ definitions:
         x-validation: true
       lms_state:
         enum:
+        - initial_sync_processing
+        - pending_authorization
         - matching_in_progress
         - error
         - disconnected


### PR DESCRIPTION
## Clever Coding Standards Agreement

- [X] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

## JIRA
[SHAPI-1798](https://clever.atlassian.net/browse/SHAPI-1798)

## Overview

Updates District model with LMS Connect Initializer values for LMS state.

## Testing

n/a for documentation change, but see the current definition of [LmsState](https://github.com/Clever/lms-service/blob/01882b60fcda240200099c4eedaf85f099cbef7c/swagger.yml#L1475-L1483) in lms-service.

## Rollout

Up to Partner Engineering, but this one is a backfill of old behavior

## Rollback

Revert PR

[SHAPI-1798]: https://clever.atlassian.net/browse/SHAPI-1798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ